### PR TITLE
Fix compilation when TRE_USE_SYSTEM_REGEX

### DIFF
--- a/lib/tre.h
+++ b/lib/tre.h
@@ -54,6 +54,8 @@ typedef int reg_errcode_t;
 #define REG_RIGHT_ASSOC (REG_LITERAL << 1)
 #define REG_UNGREEDY    (REG_RIGHT_ASSOC << 1)
 
+#define REG_USEBYTES    (REG_UNGREEDY << 1)
+
 /* Extra tre_regexec() flags. */
 #define REG_APPROX_MATCHER	 0x1000
 #define REG_BACKTRACKING_MATCHER (REG_APPROX_MATCHER << 1)


### PR DESCRIPTION
tre.h was changed to define `REG_USEBYTES` if `TRE_USE_SYSTEM_REGEX` was undefined which broke the compilation step when it was defined. This fixes the compilation by defining REG_USEBYTES.

Error message:

```
make  all-recursive
make[1]: Entering directory `/usr/share/media/src/git/tre'
Making all in lib
make[2]: Entering directory `/usr/share/media/src/git/tre/lib'
make  all-am
make[3]: Entering directory `/usr/share/media/src/git/tre/lib'
/bin/sh ../libtool --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..     -g -O2 -MT tre-ast.lo -MD -MP -MF .deps/tre-ast.Tpo -c -o tre-ast.lo tre-ast.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -g -O2 -MT tre-ast.lo -MD -MP -MF .deps/tre-ast.Tpo -c tre-ast.c  -fPIC -DPIC -o .libs/tre-ast.o
mv -f .deps/tre-ast.Tpo .deps/tre-ast.Plo
/bin/sh ../libtool --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..     -g -O2 -MT tre-compile.lo -MD -MP -MF .deps/tre-compile.Tpo -c -o tre-compile.lo tre-compile.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -g -O2 -MT tre-compile.lo -MD -MP -MF .deps/tre-compile.Tpo -c tre-compile.c  -fPIC -DPIC -o .libs/tre-compile.o
tre-compile.c: In function 'tre_compile':
tre-compile.c:1894:33: error: 'REG_USEBYTES' undeclared (first use in this function)
   parse_ctx.cur_max = (cflags & REG_USEBYTES) ? 1 : TRE_MB_CUR_MAX;
                                 ^
tre-compile.c:1894:33: note: each undeclared identifier is reported only once for each function it appears in
make[3]: *** [tre-compile.lo] Error 1
make[3]: Leaving directory `/usr/share/media/src/git/tre/lib'
make[2]: *** [all] Error 2
make[2]: Leaving directory `/usr/share/media/src/git/tre/lib'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/usr/share/media/src/git/tre'
make: *** [all] Error 2
```
