### PR TITLE
not defining 'snprintf' if in visual studio 2015

### DIFF
--- a/win32/config.h
+++ b/win32/config.h
@@ -180,4 +180,6 @@
 /* Avoid silly warnings about "insecure" functions. */
 #define _CRT_SECURE_NO_DEPRECATE 1
 
-#define snprintf sprintf_s
+#if (!defined _MSC_VER) || (_MSC_VER < 1900) /* not needed in vs2015 */
+	#define snprintf sprintf_s
+#endif


### PR DESCRIPTION
visual studio 2015 (v14) added support for snprintf and raises error in stdio.h when it's already defined.
