### PR TITLE
Attempt to fix flaw causing R bug 15012

### DIFF
--- a/lib/tre-parse.c
+++ b/lib/tre-parse.c
@@ -1341,8 +1341,9 @@ tre_parse(tre_parse_ctx_t *ctx)
 
 	    case CHAR_RPAREN:  /* end of current subexpression */
 	      if ((ctx->cflags & REG_EXTENDED && depth > 0)
-		  || (ctx->re > ctx->re_start
-		      && *(ctx->re - 1) == CHAR_BACKSLASH))
+		  || (!(ctx->cflags & REG_EXTENDED)
+		      && (ctx->re > ctx->re_start
+			  && *(ctx->re - 1) == CHAR_BACKSLASH)))
 		{
 		  DPRINT(("tre_parse:	    empty: '%.*" STRF "'\n",
 			  REST(ctx->re)));


### PR DESCRIPTION
The R bug report is [here](https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=15012).

Also reproducible with:
`echo "" | agrep -e '\\)'`

The patched version passes `make check`, and `agrep` is able to finish quickly with this test pattern (and not consume all available memory). As I'm not too familiar with the TRE internals, I hope this doesn't cause other bugs.