### PR TITLE
Fix bitfield use in tre-match-backtrack.c

### DIFF
--- a/lib/tre-match-backtrack.c
+++ b/lib/tre-match-backtrack.c
@@ -424,7 +424,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 	  DPRINT(("  should match back reference %d\n", bt));
 	  /* Get the substring we need to match against.  Remember to
 	     turn off REG_NOSUB temporarily. */
-	  tre_fill_pmatch(bt + 1, pmatch, tnfa->cflags & /*LINTED*/!REG_NOSUB,
+	  tre_fill_pmatch(bt + 1, pmatch, tnfa->cflags & ~REG_NOSUB,
 			  tnfa, tags, pos);
 	  so = pmatch[bt].rm_so;
 	  eo = pmatch[bt].rm_eo;
@@ -600,7 +600,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 	  if (stack->prev)
 	    {
 	      DPRINT(("	 backtracking\n"));
-	      if (stack->item.state->assertions && ASSERT_BACKREF)
+	      if (stack->item.state->assertions & ASSERT_BACKREF)
 		{
 		  DPRINT(("  states_seen[%d] = 0\n",
 			  stack->item.state_id));


### PR DESCRIPTION
Switch from logical to bitwise operators so the bitflags are actually set/tested properly.