### PR TITLE
Add distinct error message for maximum number in {} being too large

### DIFF
--- a/doc/tre-api.html
+++ b/doc/tre-api.html
@@ -190,7 +190,7 @@ invalid.</dd>
 <dd><tt>\{\}</tt> or <tt>{}</tt> imbalance.</dd>
 <dt><tt>REG_BADBR</tt></dt>
 <dd><tt>{}</tt> content invalid: not a number, more than two numbers,
-first larger than second, or number too large.
+or first larger than second.
 <dt><tt>REG_ERANGE</tt></dt>
 <dd>Invalid character range, e.g. ending point is earlier in the
 collating order than the starting point.</dd>
@@ -199,6 +199,8 @@ collating order than the starting point.</dd>
 <dt><tt>REG_BADRPT</tt></dt>
 <dd>Invalid use of repetition operators: two or more repetition operators have
 been chained in an undefined way.</dd>
+<dt><tt>REG_BADMAX</tt></dt>
+<dd>Maximum repetition in ><tt>{}</tt> too large.</dd>
 </dl>
 </blockquote>
 

--- a/include/tre/tre.h
+++ b/include/tre/tre.h
@@ -91,7 +91,8 @@ typedef enum {
   REG_BADBR,		/* Invalid content of {} */
   REG_ERANGE,		/* Invalid use of range operator */
   REG_ESPACE,		/* Out of memory.  */
-  REG_BADRPT            /* Invalid use of repetition operators. */
+  REG_BADRPT,		/* Invalid use of repetition operators. */
+  REG_BADMAX,		/* Maximum repetition in {} too large */
 } reg_errcode_t;
 
 /* POSIX tre_regcomp() flags. */

--- a/lib/regerror.c
+++ b/lib/regerror.c
@@ -47,7 +47,8 @@ static const char *tre_error_messages[] =
     gettext_noop("Invalid contents of {}"),		 /* REG_BADBR */
     gettext_noop("Invalid character range"),		 /* REG_ERANGE */
     gettext_noop("Out of memory"),			 /* REG_ESPACE */
-    gettext_noop("Invalid use of repetition operators")	 /* REG_BADRPT */
+    gettext_noop("Invalid use of repetition operators"), /* REG_BADRPT */
+    gettext_noop("Maximum repetition in {} too large"),	 /* REG_BADMAX */
   };
 
 size_t

--- a/lib/regerror.c
+++ b/lib/regerror.c
@@ -31,24 +31,27 @@
 #define _(String) dgettext(PACKAGE, String)
 #define gettext_noop(String) String
 
+#define xstr(s) str(s)
+#define str(s) #s
+
 /* Error message strings for error codes listed in `tre.h'.  This list
    needs to be in sync with the codes listed there, naturally. */
 static const char *tre_error_messages[] =
-  { gettext_noop("No error"),				 /* REG_OK */
-    gettext_noop("No match"),				 /* REG_NOMATCH */
-    gettext_noop("Invalid regexp"),			 /* REG_BADPAT */
-    gettext_noop("Unknown collating element"),		 /* REG_ECOLLATE */
-    gettext_noop("Unknown character class name"),	 /* REG_ECTYPE */
-    gettext_noop("Trailing backslash"),			 /* REG_EESCAPE */
-    gettext_noop("Invalid back reference"),		 /* REG_ESUBREG */
-    gettext_noop("Missing ']'"),			 /* REG_EBRACK */
-    gettext_noop("Missing ')'"),			 /* REG_EPAREN */
-    gettext_noop("Missing '}'"),			 /* REG_EBRACE */
-    gettext_noop("Invalid contents of {}"),		 /* REG_BADBR */
-    gettext_noop("Invalid character range"),		 /* REG_ERANGE */
-    gettext_noop("Out of memory"),			 /* REG_ESPACE */
-    gettext_noop("Invalid use of repetition operators"), /* REG_BADRPT */
-    gettext_noop("Maximum repetition in {} too large"),	 /* REG_BADMAX */
+  { gettext_noop("No error"),							/* REG_OK */
+    gettext_noop("No match"),							/* REG_NOMATCH */
+    gettext_noop("Invalid regexp"),						/* REG_BADPAT */
+    gettext_noop("Unknown collating element"),					/* REG_ECOLLATE */
+    gettext_noop("Unknown character class name"),				/* REG_ECTYPE */
+    gettext_noop("Trailing backslash"),						/* REG_EESCAPE */
+    gettext_noop("Invalid back reference"),					/* REG_ESUBREG */
+    gettext_noop("Missing ']'"),						/* REG_EBRACK */
+    gettext_noop("Missing ')'"),						/* REG_EPAREN */
+    gettext_noop("Missing '}'"),						/* REG_EBRACE */
+    gettext_noop("Invalid contents of {}"),					/* REG_BADBR */
+    gettext_noop("Invalid character range"),					/* REG_ERANGE */
+    gettext_noop("Out of memory"),						/* REG_ESPACE */
+    gettext_noop("Invalid use of repetition operators"),			/* REG_BADRPT */
+    gettext_noop("Maximum repetition in {} larger than " xstr(RE_DUP_MAX)),	/* REG_BADMAX */
   };
 
 size_t

--- a/lib/tre-parse.c
+++ b/lib/tre-parse.c
@@ -628,8 +628,10 @@ tre_parse_bound(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
     }
 
   /* Check that the repeat counts are sane. */
-  if ((max >= 0 && min > max) || max > RE_DUP_MAX)
+  if (max >= 0 && min > max)
     return REG_BADBR;
+  if (max > RE_DUP_MAX)
+    return REG_BADMAX;
 
 
   /*

--- a/lib/tre.h
+++ b/lib/tre.h
@@ -93,7 +93,8 @@ typedef enum {
   REG_BADBR,		/* Invalid content of {} */
   REG_ERANGE,		/* Invalid use of range operator */
   REG_ESPACE,		/* Out of memory.  */
-  REG_BADRPT            /* Invalid use of repetition operators. */
+  REG_BADRPT,		/* Invalid use of repetition operators. */
+  REG_BADMAX,		/* Maximum repetition in {} too large */
 } reg_errcode_t;
 
 /* POSIX tre_regcomp() flags. */

--- a/tests/retest.c
+++ b/tests/retest.c
@@ -1290,7 +1290,7 @@ main(int argc, char **argv)
 
   /* Shorthands for character classes. */
   test_comp("\\w+", REG_EXTENDED, 0);
-  test_exec(",.(a23_Nt-ï¿½o)", 0, REG_OK, 3, 9, END);
+  test_exec(",.(a23_Nt-öo)", 0, REG_OK, 3, 9, END);
   test_comp("\\d+", REG_EXTENDED, 0);
   test_exec("uR120_4=v4", 0, REG_OK, 2, 5, END);
   test_comp("\\D+", REG_EXTENDED, 0);
@@ -1631,15 +1631,15 @@ main(int argc, char **argv)
    */
 
   /* This same test with the correct locale is below. */
-  test_comp("ï¿½ï¿½+", REG_EXTENDED, 0);
-  test_exec("ï¿½ï¿½ï¿½Î¾Þ¤Ï¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½", 0, REG_OK, 10, 13, END);
+  test_comp("µ¡+", REG_EXTENDED, 0);
+  test_exec("¤³¤Î¾Þ¤Ï¡¢µ¡¡¦ÍøÊØÀ­¡¦¥»¥­", 0, REG_OK, 10, 13, END);
 
 #if !defined(WIN32) && !defined(__OpenBSD__)
   if (setlocale(LC_CTYPE, "en_US.ISO-8859-1") != NULL)
     {
       printf("\nTesting LC_CTYPE en_US.ISO-8859-1\n");
-      test_comp("aBCdeFghiJKlmnoPQRstuvWXyZï¿½ï¿½ï¿½", REG_ICASE, 0);
-      test_exec("abCDefGhiJKlmNoPqRStuVwXyzï¿½ï¿½ï¿½", 0, REG_OK, 0, 29, END);
+      test_comp("aBCdeFghiJKlmnoPQRstuvWXyZåäö", REG_ICASE, 0);
+      test_exec("abCDefGhiJKlmNoPqRStuVwXyzÅÄÖ", 0, REG_OK, 0, 29, END);
     }
 
 #ifdef TRE_MULTIBYTE
@@ -1649,8 +1649,8 @@ main(int argc, char **argv)
       /* I tried to make a test where implementations not aware of multibyte
 	 character sets will fail.  I have no idea what the japanese text here
 	 means, I took it from http://www.ipsec.co.jp/. */
-      test_comp("ï¿½ï¿½+", REG_EXTENDED, 0);
-      test_exec("ï¿½ï¿½ï¿½Î¾Þ¤Ï¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½", 0, REG_OK, 10, 12, END);
+      test_comp("µ¡+", REG_EXTENDED, 0);
+      test_exec("¤³¤Î¾Þ¤Ï¡¢µ¡¡¦ÍøÊØÀ­¡¦¥»¥­", 0, REG_OK, 10, 12, END);
 
       test_comp("a", REG_EXTENDED, 0);
       test_nexec("foo\000bar", 7, 0, REG_OK, 5, 6, END);

--- a/tests/retest.c
+++ b/tests/retest.c
@@ -1290,7 +1290,7 @@ main(int argc, char **argv)
 
   /* Shorthands for character classes. */
   test_comp("\\w+", REG_EXTENDED, 0);
-  test_exec(",.(a23_Nt-öo)", 0, REG_OK, 3, 9, END);
+  test_exec(",.(a23_Nt-ï¿½o)", 0, REG_OK, 3, 9, END);
   test_comp("\\d+", REG_EXTENDED, 0);
   test_exec("uR120_4=v4", 0, REG_OK, 2, 5, END);
   test_comp("\\D+", REG_EXTENDED, 0);
@@ -1621,6 +1621,7 @@ main(int argc, char **argv)
   test_comp("a\\{1,0\\}", 0, REG_BADBR);
   test_comp("a\\{x\\}", 0, REG_BADBR);
   test_comp("a\\{\\}", 0, REG_BADBR);
+  test_comp("a\\{1,256\\}", 0, REG_BADMAX);
 
 
 
@@ -1630,15 +1631,15 @@ main(int argc, char **argv)
    */
 
   /* This same test with the correct locale is below. */
-  test_comp("µ¡+", REG_EXTENDED, 0);
-  test_exec("¤³¤Î¾Þ¤Ï¡¢µ¡¡¦ÍøÊØÀ­¡¦¥»¥­", 0, REG_OK, 10, 13, END);
+  test_comp("ï¿½ï¿½+", REG_EXTENDED, 0);
+  test_exec("ï¿½ï¿½ï¿½Î¾Þ¤Ï¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½", 0, REG_OK, 10, 13, END);
 
 #if !defined(WIN32) && !defined(__OpenBSD__)
   if (setlocale(LC_CTYPE, "en_US.ISO-8859-1") != NULL)
     {
       printf("\nTesting LC_CTYPE en_US.ISO-8859-1\n");
-      test_comp("aBCdeFghiJKlmnoPQRstuvWXyZåäö", REG_ICASE, 0);
-      test_exec("abCDefGhiJKlmNoPqRStuVwXyzÅÄÖ", 0, REG_OK, 0, 29, END);
+      test_comp("aBCdeFghiJKlmnoPQRstuvWXyZï¿½ï¿½ï¿½", REG_ICASE, 0);
+      test_exec("abCDefGhiJKlmNoPqRStuVwXyzï¿½ï¿½ï¿½", 0, REG_OK, 0, 29, END);
     }
 
 #ifdef TRE_MULTIBYTE
@@ -1648,8 +1649,8 @@ main(int argc, char **argv)
       /* I tried to make a test where implementations not aware of multibyte
 	 character sets will fail.  I have no idea what the japanese text here
 	 means, I took it from http://www.ipsec.co.jp/. */
-      test_comp("µ¡+", REG_EXTENDED, 0);
-      test_exec("¤³¤Î¾Þ¤Ï¡¢µ¡¡¦ÍøÊØÀ­¡¦¥»¥­", 0, REG_OK, 10, 12, END);
+      test_comp("ï¿½ï¿½+", REG_EXTENDED, 0);
+      test_exec("ï¿½ï¿½ï¿½Î¾Þ¤Ï¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½", 0, REG_OK, 10, 12, END);
 
       test_comp("a", REG_EXTENDED, 0);
       test_nexec("foo\000bar", 7, 0, REG_OK, 5, 6, END);


### PR DESCRIPTION
This PR add a distinct error message for the maximum number in `{}` being too large (hard-coded to `255` in `tre.h`).

We recently switched to using `tre-regex` in [`Pi-hole`](https://github.com/pi-hole/pi-hole) and received a report today, that the regex
``` plain
a{2,256}
```
was returning 
```
{} content invalid
```
(return code `REG_BADBR`).

This was a bit of a mystery at first, as GNU regex doesn't seem to enforce a maximum number of iterations in a bound expression. I propose adding an explicit warning message to help users seeing what is wrong.

The new return code `REG_BADMAX` has a distinct error message including the upper limit:
``` plain
Maximum repetition in {} larger than 255
```
Including the limit here seems meaningful as the limit is set at compile time and not customizable during runtime. Hence, users have no access to its actual value otherwise. I use stringification of the C preprocessor to implement this transparently and without overhead. 

I added a test case for the new return type. `make check` passes.