### PR TITLE
Partial zh_CN translation + README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,43 +255,44 @@ These are other features I'm planning to implement real soon now:
 
 * Perl-compatible syntax
   * `[:^class:]`  
-  *  Matches anything but the characters in class. Note that
-  *  [^[:class:]] works already, this would be just a
-  *  convenience shorthand.
-  * 
+    Matches anything but the characters in class. Note that
+    `[^[:class:]]` works already, this would be just a
+    convenience shorthand.
+
   * `\A`  
-  * Match only at beginning of string
-  * 
+    Match only at beginning of string
+
   * `\Z`  
-  * Match only at end of string, or before newline at the end
-  * 
+    Match only at end of string, or before newline at the end
+
   * `\z`  
-  * Match only at end of string
-  * 
+    Match only at end of string
+
   * `\l`  
-  * Lowercase next char (think vi)
-  * 
+    Lowercase next char (think vi)
+
   * `\u`  
-  * Uppercase next char (think vi)
-  * 
+    Uppercase next char (think vi)
+
   * `\L`  
-  * Lowercase till \E (think vi)
-  * 
+    Lowercase till \E (think vi)
+
   * `\U`  
-  * Uppercase till \E (think vi)
-  * 
+    Uppercase till \E (think vi)
+
   * `(?=pattern)`  
-  * Zero-width positive look-ahead assertions.
-  * 
+    Zero-width positive look-ahead assertions.
+
   * `(?!pattern)`  
-  * Zero-width negative look-ahead assertions.
-  * 
+    Zero-width negative look-ahead assertions.
+
   * `(?<=pattern)`  
-  * Zero-width positive look-behind assertions.
-  * 
+    Zero-width positive look-behind assertions.
+
   * `(?<!pattern)`
-  * Zero-width negative look-behind assertions.
+    Zero-width negative look-behind assertions.
 
 Documentation especially for the nonstandard features of TRE, such
 as approximate matching, is a work in progress (with "progress"
-loosely defined...)
+loosely defined...)  If you want to find an extension to use, reading
+the `tre.h` header is more helpful.

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,3 +1,4 @@
 # Set of available languages.
 fi
 sv
+zh_CN

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,205 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Ville Laurikari
+# This file is distributed under the same license as the tre package.
+# Mingye Wang <arthur200126@gmail.com>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: tre 0.8.0\n"
+"Report-Msgid-Bugs-To: tre-general@lists.laurikari.net\n"
+"POT-Creation-Date: 2016-03-05 20:29-0700\n"
+"PO-Revision-Date: 2021-05-19 16:01+0800\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2.3\n"
+"Last-Translator: Mingye Wang <arthur200126@gmail.com>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: zh_CN\n"
+
+#: lib/regerror.c:37
+msgid "No error"
+msgstr "无错误"
+
+#: lib/regerror.c:38
+msgid "No match"
+msgstr "无匹配项"
+
+#: lib/regerror.c:39
+msgid "Invalid regexp"
+msgstr "正则表达式无效"
+
+#: lib/regerror.c:40
+msgid "Unknown collating element"
+msgstr "未知的字符排序组合"
+
+#: lib/regerror.c:41
+msgid "Unknown character class name"
+msgstr "未知的字符类名"
+
+#: lib/regerror.c:42
+msgid "Trailing backslash"
+msgstr "末尾有反斜杠"
+
+#: lib/regerror.c:43
+msgid "Invalid back reference"
+msgstr "无效的回引用"
+
+#: lib/regerror.c:44
+msgid "Missing ']'"
+msgstr "缺少 \"]\""
+
+#: lib/regerror.c:45
+msgid "Missing ')'"
+msgstr "缺少 \")\""
+
+#: lib/regerror.c:46
+msgid "Missing '}'"
+msgstr "缺少 \"}\""
+
+#: lib/regerror.c:47
+msgid "Invalid contents of {}"
+msgstr "无效的 {} 内容"
+
+#: lib/regerror.c:48
+msgid "Invalid character range"
+msgstr "无效字符范围"
+
+#: lib/regerror.c:49 src/agrep.c:229 src/agrep.c:299 src/agrep.c:324
+#: src/agrep.c:695 src/agrep.c:734
+msgid "Out of memory"
+msgstr "内存不足"
+
+#: lib/regerror.c:50
+msgid "Invalid use of repetition operators"
+msgstr "无效的重复运算符用法"
+
+#: lib/regerror.c:65
+msgid "Unknown error"
+msgstr "未知的错误"
+
+#: src/agrep.c:96 src/agrep.c:103
+#, c-format
+msgid "Usage: %s [OPTION]... PATTERN [FILE]...\n"
+msgstr "用法：%s [选项]... 模式 [文件]...\n"
+
+#: src/agrep.c:98
+#, c-format
+msgid "Try `%s --help' for more information.\n"
+msgstr "试用“%s --help”以获取更多信息。\n"
+
+#: src/agrep.c:104
+#, c-format
+msgid ""
+"Searches for approximate matches of PATTERN in each FILE or standard "
+"input.\n"
+"Example: `%s -2 optimize foo.txt' outputs all lines in file `foo.txt' "
+"that\n"
+"match \"optimize\" within two errors.  E.g. lines which contain \"optimise"
+"\",\n"
+"\"optmise\", and \"opitmize\" all match.\n"
+msgstr ""
+
+#: src/agrep.c:110
+#, c-format
+msgid ""
+"Regexp selection and interpretation:\n"
+"  -e, --regexp=PATTERN\t    use PATTERN as a regular expression\n"
+"  -i, --ignore-case\t    ignore case distinctions\n"
+"  -k, --literal\t\t    PATTERN is a literal string\n"
+"  -w, --word-regexp\t    force PATTERN to match only whole words\n"
+"\n"
+"Approximate matching settings:\n"
+"  -D, --delete-cost=NUM\t    set cost of missing characters\n"
+"  -I, --insert-cost=NUM\t    set cost of extra characters\n"
+"  -S, --substitute-cost=NUM set cost of wrong characters\n"
+"  -E, --max-errors=NUM\t    select records that have at most NUM errors\n"
+"  -#\t\t\t    select records that have at most # errors (# is a\n"
+"\t\t\t    digit between 0 and 9)\n"
+"\n"
+"Miscellaneous:\n"
+"  -d, --delimiter=PATTERN   set the record delimiter regular expression\n"
+"  -v, --invert-match\t    select non-matching records\n"
+"  -V, --version\t\t    print version information and exit\n"
+"  -y, --nothing\t\t    does nothing (for compatibility with the non-free\n"
+"\t\t\t    agrep program)\n"
+"      --help\t\t    display this help and exit\n"
+"\n"
+"Output control:\n"
+"  -B, --best-match\t    only output records with least errors\n"
+"  -c, --count\t\t    only print a count of matching records per FILE\n"
+"  -h, --no-filename\t    suppress the prefixing filename on output\n"
+"  -H, --with-filename\t    print the filename for each match\n"
+"  -l, --files-with-matches  only print FILE names containing matches\n"
+"  -M, --delimiter-after     print record delimiter after record if -d is "
+"used\n"
+"  -n, --record-number\t    print record number with output\n"
+"      --line-number         same as -n\n"
+"  -q, --quiet, --silent\t    suppress all normal output\n"
+"  -s, --show-cost\t    print match cost with output\n"
+"      --colour, --color     use markers to distinguish the matching "
+"strings\n"
+"      --show-position       prefix each output record with start and end\n"
+"                            position of the first match within the "
+"record\n"
+msgstr ""
+
+#: src/agrep.c:149
+#, c-format
+msgid ""
+"With no FILE, or when FILE is -, reads standard input.  If less than two\n"
+"FILEs are given, -h is assumed.  Exit status is 0 if a match is found, 1 "
+"for\n"
+"no match, and 2 if there were errors.  If -E or -# is not specified, "
+"only\n"
+"exact matches are selected.\n"
+msgstr ""
+
+#: src/agrep.c:155
+#, c-format
+msgid ""
+"PATTERN is a POSIX extended regular expression (ERE) with the TRE "
+"extensions.\n"
+"See tre(7) for a complete description.\n"
+msgstr ""
+
+#: src/agrep.c:159
+#, c-format
+msgid "Report bugs to: "
+msgstr "将错误报告给："
+
+#: src/agrep.c:244
+#, c-format
+msgid "Error reading from %s: %s\n"
+msgstr "读取“%s”时出错：%s\n"
+
+#: src/agrep.c:339
+msgid "Cannot use -B when reading from standard input."
+msgstr ""
+
+#: src/agrep.c:343
+msgid "(standard input)"
+msgstr "(标准输入)"
+
+#: src/agrep.c:600
+#, c-format
+msgid "Copyright (c) 2001-2009 Ville Laurikari <vl@iki.fi>.\n"
+msgstr "版权所有 © 2001-2009 Ville Laurikari <vl@iki.fi>。\n"
+
+#: src/agrep.c:622
+#, c-format
+msgid "%s: invalid option --%s\n"
+msgstr "%s：无效选项 --%s\n"
+
+#: src/agrep.c:749
+msgid "Error in search pattern"
+msgstr "搜索模式有误"
+
+#: src/agrep.c:760
+msgid "Error in record delimiter pattern"
+msgstr ""
+
+#: src/agrep.c:767
+msgid "Record delimiter pattern must not match an empty string"
+msgstr ""


### PR DESCRIPTION
This PR contains a partial zh_CN translation, in that the error messages are done but not the longer help messages. I also fixed up the README by a bit, so the last section about what PCRE extensions to include make more sense. I also added a sensence pointing people to the header if they want to see what functions provide the extensions, as I don't think I have the time to edit the HTML docs yet.