### PR TITLE
Remove broken agrep test entry (fails with bash >= 5.2)

### DIFF
--- a/tests/agrep/exitstatus.args
+++ b/tests/agrep/exitstatus.args
@@ -5,6 +5,5 @@ this-wont-be-found
 .
 -v .
 # Some errors which should give exit status 2.
--d .* dummy
 -d {1 dummy
 \

--- a/tests/agrep/exitstatus.ok
+++ b/tests/agrep/exitstatus.ok
@@ -522,67 +522,6 @@ Exit status 1.
 #### TEST: agrep -H -n -s --color --show-position -v . < exitstatus.in
 
 Exit status 1.
-#### TEST: agrep  -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep  -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -c -d .* dummy exitstatus.in
-exitstatus.in:0
-
-Exit status 1.
-#### TEST: agrep -c -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -H -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -H -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -l -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -l -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -n -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -n -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -s -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -s -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -M -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -M -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep --show-position -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep --show-position -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep --color -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep --color -d .* dummy < exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -H -n -s --color --show-position -d .* dummy exitstatus.in
-
-Exit status 1.
-#### TEST: agrep -H -n -s --color --show-position -d .* dummy < exitstatus.in
-
-Exit status 1.
 #### TEST: agrep  -d {1 dummy exitstatus.in
 
 Exit status 2.


### PR DESCRIPTION
It's meant to cause agrep to return with exit code 2, but asserts that it's exit code 1 instead.

It's meant to ensure that using `.*` as pattern results in exit code 2 because it matches also an empty string. However, glob expansion results in `.*` picking up files such as `.` and `..` from the CWD, which get interpreted as valid pattern. This results in exit status 1 (no match found) which is what the .ok file expects, but that's invalid.

With bash 5.2, glob expansion no longer matches `.` and `..` by default, so the test works as intended by accident, causing a mismatch with the expected wrong exit code.

It's unfortunately not easily possible to avoid glob expansion in this case.

Just remove the test for now.