### PR TITLE
Fix compilation error when using system regex.h

### DIFF
--- a/include/tre/tre.h
+++ b/include/tre/tre.h
@@ -47,6 +47,9 @@ typedef int reg_errcode_t;
 #define REG_LITERAL 0x1000
 #endif
 
+/* Extra tre_regcomp() return error codes. */
+#define REG_BADMAX REG_BADPAT
+
 /* Extra tre_regcomp() flags. */
 #ifndef REG_BASIC
 #define REG_BASIC	0


### PR DESCRIPTION
Missing `REG_BADMAX` macro (introduced in 5b05692e07ee2e3deb22c73f621e031937e85fc4) when using POSIX regex.h.

Fixes error when compiling `tre-parse.c`: `error: 'REG_BADMAX' undeclared`

Use `./configure --enable-system-abi` to reproduce.

<details><summary>Compilation output (23lines)</summary>

```
$ make -j1 -C lib
make: Entering directory '/usr/src/git/tre/lib'
/bin/sh ../libtool  --tag=CC   --mode=compile ccache cc -DHAVE_CONFIG_H -I. -I.. -I../include/tre  -I../include/tre   -g -O2 -Wall -MT tre-parse.lo -MD -MP -MF .deps/tre-parse.Tpo -c -o tre-parse.lo tre-parse.c
libtool: compile:  ccache cc -DHAVE_CONFIG_H -I. -I.. -I../include/tre -I../include/tre -g -O2 -Wall -MT tre-parse.lo -MD -MP -MF .deps/tre-parse.Tpo -c tre-parse.c  -fPIC -DPIC -o .libs/tre-parse.o
In file included from tre-internal.h:22,
                 from tre-ast.h:14,
                 from tre-parse.c:25:
../include/tre/tre.h:140:20: warning: argument 4 of type 'regmatch_t[]' declared as an ordinary array [-Wvla-parameter]
  140 |         regmatch_t pmatch[], int eflags);
      |         ~~~~~~~~~~~^~~~~~~~
In file included from ../include/tre/tre.h:25:
/usr/include/regex.h:681:32: note: previously declared as a variable length array 'regmatch_t[restrict  __nmatch]'
  681 |                     regmatch_t __pmatch[_Restrict_arr_
      |                     ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
  682 |                                         _REGEX_NELTS (__nmatch)],
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~
tre-parse.c: In function 'tre_parse_bound':
tre-parse.c:634:12: error: 'REG_BADMAX' undeclared (first use in this function); did you mean 'REG_BADPAT'?
  634 |     return REG_BADMAX;
      |            ^~~~~~~~~~
      |            REG_BADPAT
tre-parse.c:634:12: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:506: tre-parse.lo] Error 1
make: Leaving directory '/usr/src/git/tre/lib'
```
</details>