### PR TITLE
Fix install location for headers

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,1 +1,2 @@
-include_HEADERS = tre/tre.h tre/regex.h tre/tre-config.h
+treincludedir = $(includedir)/tre
+treinclude_HEADERS = tre/tre.h tre/regex.h tre/tre-config.h


### PR DESCRIPTION
They were installed in /usr/include, which is wrong, and installing regex.h there clobbers glibc's copy.

Seen when using GNU autotools, no word on using `waf`.

They should be installed in `/usr/include/tre`