### PR TITLE
Allow the minimum count of a bound to be omitted

### DIFF
--- a/doc/tre-syntax.html
+++ b/doc/tre-syntax.html
@@ -126,16 +126,23 @@ are unsigned decimal integers between <tt>0</tt> and
 
 <ol>
 <li><tt>{</tt><i>m</i><tt>,</tt><i>n</i><tt>}</tt></li>
+<li><tt>{,</tt><i>n</i><tt>}</tt></li>
 <li><tt>{</tt><i>m</i><tt>,}</tt></li>
 <li><tt>{</tt><i>m</i><tt>}</tt></li>
+<li><tt>{,}</tt></li>
 </ol>
 
 <p>
 An atom followed by [1] matches a sequence of <i>m</i> through <i>n</i>
-(inclusive) matches of the atom.  An atom followed by [2]
-matches a sequence of <i>m</i> or more matches of the atom.  An atom
-followed by [3] matches a sequence of exactly <i>m</i> matches of the
-atom.
+(inclusive) matches of the atom.
+An atom followed by [2] matches a sequence of up to <i>n</i> matches
+of the atom.
+An atom followed by [3] matches a sequence of <i>m</i> or more matches
+of the atom.
+An atom followed by [4] matches a sequence of exactly <i>m</i> matches
+of the atom.
+An atom followed by [5] matches a sequence of zero or more matches of
+the atom.
 </p>
 
 

--- a/lib/tre-parse.c
+++ b/lib/tre-parse.c
@@ -635,6 +635,8 @@ tre_parse_bound(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
   max = min;
   if (r < ctx->re_end && *r == CHAR_COMMA)
     {
+      if (min < 0)
+	min = 0;
       r++;
       DPRINT(("tre_parse:   max count: '%.*" STRF "'\n", REST(r)));
       max = tre_parse_int(&r, ctx->re_end);

--- a/tests/retest.c
+++ b/tests/retest.c
@@ -1480,6 +1480,21 @@ main(int argc, char **argv)
   test_exec("aaaaa", 0, REG_OK, 0, 5, END);
   test_exec("aaaaaa", 0, REG_OK, 0, 6, END);
   test_exec("aaaaaaa", 0, REG_OK, 0, 7, END);
+  test_comp("a{,}", REG_EXTENDED, REG_OK);
+  test_exec("", 0, REG_OK, 0, 0, END);
+  test_exec("aaa", 0, REG_OK, 0, 3, END);
+  test_comp("a{,0}", REG_EXTENDED, REG_OK);
+  test_exec("", 0, REG_OK, 0, 0, END);
+  test_exec("aaa", 0, REG_OK, 0, 0, END);
+  test_comp("a{,1}", REG_EXTENDED, REG_OK);
+  test_exec("", 0, REG_OK, 0, 0, END);
+  test_exec("a", 0, REG_OK, 0, 1, END);
+  test_exec("aa", 0, REG_OK, 0, 1, END);
+  test_comp("a{,2}", REG_EXTENDED, REG_OK);
+  test_exec("", 0, REG_OK, 0, 0, END);
+  test_exec("a", 0, REG_OK, 0, 1, END);
+  test_exec("aa", 0, REG_OK, 0, 2, END);
+  test_exec("aaa", 0, REG_OK, 0, 2, END);
 
   test_comp("a{5,10}", REG_EXTENDED, REG_OK);
   test_comp("a{6,6}", REG_EXTENDED, REG_OK);


### PR DESCRIPTION
This fixes #62.