### PR TITLE
Simplify AST expansion

### DIFF
--- a/lib/tre-compile.c
+++ b/lib/tre-compile.c
@@ -936,7 +936,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 		  {
 		    for (j = iter->min; j < iter->max; j++)
 		      {
-			tre_ast_node_t *tmp, *copy;
+			tre_ast_node_t *copy;
 			pos_add_save = pos_add;
 			status = tre_copy_ast(mem, stack, iter->arg, 0,
 					      &pos_add, NULL, &copy, &max_pos);
@@ -948,10 +948,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 			  seq2 = copy;
 			if (seq2 == NULL)
 			  return REG_ESPACE;
-			tmp = tre_ast_new_literal(mem, EMPTY, -1);
-			if (tmp == NULL)
-			  return REG_ESPACE;
-			seq2 = tre_ast_new_union(mem, tmp, seq2);
+			seq2 = tre_ast_new_iter(mem, seq2, 0, 1, 0);
 			if (seq2 == NULL)
 			  return REG_ESPACE;
 		      }


### PR DESCRIPTION
Improved performance of `retest` with the patches in this PR (each data point is the time taken to run 10 times, lower is better):

```
x before
+ after
+------------------------------------------------------------------------------+
|   +                                                               x          |
|   +  +   +  +                                            x        x      x   |
|+  +  +   +  +                                            x     x  x   x  x  x|
|  |___MA___|                                                 |_____MA_____|   |
+------------------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10          3.63          3.69          3.66         3.661   0.020248457
+  10          3.45          3.49          3.47         3.471   0.013703203
Difference at 95.0% confidence
	-0.19 +/- 0.0162441
	-5.18984% +/- 0.428046%
	(Student's t, pooled s = 0.0172884)
```

Improved performance of `wretest` with the patches in this PR (each data point is the time taken to run 10 times, lower is better):

```
x wbefore
+ wafter
+------------------------------------------------------------------------------+
|              +                                                   x           |
|         + +  +                                                x  x x  x      |
|+  +     + +  +  +                                             x  x x  x     x|
|     |____AM____|                                              |___MA___|     |
+------------------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10          3.68          3.73         3.695         3.698   0.015491933
+  10          3.46          3.52           3.5         3.496   0.018973666
Difference at 95.0% confidence
	-0.202 +/- 0.0162743
	-5.46241% +/- 0.430629%
	(Student's t, pooled s = 0.0173205)
```