### PR TITLE
Avoid use-after-free warning

### DIFF
--- a/lib/xmalloc.c
+++ b/lib/xmalloc.c
@@ -340,6 +340,7 @@ xrealloc_impl(void *ptr, size_t new_size, const char *file, int line,
   new_ptr = realloc(ptr, new_size);
   if (new_ptr != NULL)
     {
+      ptr = NULL;
       hash_table_del(xmalloc_table, ptr);
       hash_table_add(xmalloc_table, new_ptr, (int)new_size, file, line, func);
     }


### PR DESCRIPTION
More recent versions of GCC try to check for use after free. Realloc will take the input pointer, `ptrn` and with free it after a successful allocation. However, it will not change the contents of the pointer, and thus GCC in some cases thinks it can/could be used. By explicitly setting `ptrn` to NULL after an successful allocation, we can keep GCC happy and our codebase sane.