### PR TITLE
Fix wretest locale check

### DIFF
--- a/tests/retest.c
+++ b/tests/retest.c
@@ -607,7 +607,8 @@ main(int argc, char **argv)
 #ifdef WRETEST
   /* Need an 8-bit locale.  Or move the two tests with non-ascii
      characters to the localized internationalization tests.  */
-  if (setlocale(LC_CTYPE, "en_US.ISO-8859-1") == NULL)
+  if (setlocale(LC_CTYPE, "en_US.ISO-8859-1") == NULL &&
+      setlocale(LC_CTYPE, "en_US.ISO8859-1") == NULL)
     fprintf(stderr, "Could not set locale en_US.ISO-8859-1.  Expect some\n"
 		    "`Invalid or incomplete multi-byte sequence' errors.\n");
 #endif /* WRETEST */
@@ -1724,7 +1725,7 @@ main(int argc, char **argv)
 
 #if !defined(WIN32) && !defined(__OpenBSD__)
   if (setlocale(LC_CTYPE, "en_US.ISO-8859-1") != NULL ||
-      setlocale(LC_CTYPE, "en_US.ISO8859-1" /* FreeBSD seems to spell it differently */) != NULL)
+      setlocale(LC_CTYPE, "en_US.ISO8859-1") != NULL)
     {
       fprintf(output_fd,"\nTesting LC_CTYPE en_US.ISO-8859-1\n");
 #ifdef SRC_IN_ISO_8859_1


### PR DESCRIPTION
Some OSes (not just FreeBSD) spell ISO-8859 without a hyphen. There was a workaround for this in one of the two places where we set the locale; copy the workaround to the other place.

Note that the hyphenated spelling is less common than the unhyphenated one, so a better fix might be to just drop the hyphen, but this will do for now.