### PR TITLE
Postpone position assignment

### DIFF
--- a/lib/tre-ast.c
+++ b/lib/tre-ast.c
@@ -33,7 +33,7 @@ tre_ast_new_node(tre_mem_t mem, tre_ast_type_t type, size_t size)
 }
 
 tre_ast_node_t *
-tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max, int position)
+tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max)
 {
   tre_ast_node_t *node;
   tre_literal_t *lit;
@@ -44,7 +44,7 @@ tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max, int position)
   lit = node->obj;
   lit->code_min = code_min;
   lit->code_max = code_max;
-  lit->position = position;
+  lit->position = -1;
 
   return node;
 }

--- a/lib/tre-ast.h
+++ b/lib/tre-ast.h
@@ -101,7 +101,7 @@ tre_ast_node_t *
 tre_ast_new_node(tre_mem_t mem, tre_ast_type_t type, size_t size);
 
 tre_ast_node_t *
-tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max, int position);
+tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max);
 
 tre_ast_node_t *
 tre_ast_new_iter(tre_mem_t mem, tre_ast_node_t *arg, int min, int max,

--- a/lib/tre-parse.h
+++ b/lib/tre-parse.h
@@ -26,8 +26,6 @@ typedef struct {
   int len;
   /* Current submatch ID. */
   int submatch_id;
-  /* Current position (number of literal). */
-  int position;
   /* The highest back reference or -1 if none seen so far. */
   int max_backref;
   /* This flag is set if the regexp uses approximate matching. */

--- a/tests/retest.c
+++ b/tests/retest.c
@@ -1511,6 +1511,13 @@ main(int argc, char **argv)
   test_exec("abbabbbabaabbbbbbbbbbbba", 0, REG_OK,
 	    0, 24, 0, 10, 10, 22, END);
 
+  test_comp("^((a{1,2})?x)*y", REG_EXTENDED | REG_NOSUB, REG_OK);
+  test_exec("y", 0, REG_OK, END);
+  test_exec("xy", 0, REG_OK, END);
+  test_exec("axy", 0, REG_OK, END);
+  test_exec("aaxy", 0, REG_OK, END);
+  test_exec("aaaxy", 0, REG_NOMATCH, END);
+
   /* Test repeating something that has submatches inside. */
   test_comp("(a){0,5}", REG_EXTENDED, 0);
   test_exec("", 0, REG_OK, 0, 0, -1, -1, END);


### PR DESCRIPTION
During AST expansion, it is possible for new literal nodes to be created and given the same position as existing literals.  The code attempts to reposition nodes when this happens but does not always succeed.  The result is a short-circuit in the TNFA which can manifest as an infinite loop, e.g. a bounded iteration being treated as an unbounded one.  This reshuffling can also leave positions unfilled, wasting memory.

This bug was discovered while investigating a report of an issue with a regular expression intended to accept DNS names, which turned out to accept labels of any length, instead of only up to 63 characters. Compiling the minimal reproducer `^((a{1,3})?x)*y` with debugging enabled showed the following AST after expansion:

```
catenation, sub -1, 0 tags
  catenation, sub 0, 0 tags
    catenation, sub -1, 0 tags
      assertions: bol 
      iteration {0, -1}, sub -1, 0 tags, greedy
        catenation, sub 1, 0 tags
          iteration {0, 1}, sub -1, 0 tags, greedy
            catenation, sub 2, 0 tags
              literal (a, a) (97, 97), pos 0, sub -1, 0 tags
              union, sub -1, 0 tags
                literal empty
                catenation, sub -1, 0 tags
                  literal (a, a) (97, 97), pos 2, sub -1, 0 tags
                  union, sub -1, 0 tags
                    literal empty
                    literal (a, a) (97, 97), pos 1, sub -1, 0 tags
          literal (x, x) (120, 120), pos 1, sub -1, 0 tags
    literal (y, y) (121, 121), pos 4, sub -1, 0 tags
  literal (, ) (0, 0), pos 5, sub -1, 0 tags
```

Note that the last `a` node and the `x` node both have position 1. The `y` node was moved from position 2 to position 4 during expansion; the `x` node should have been moved to position 3, but wasn't.

The solution is to postpone assigning positions to literal nodes until immediately before TNFA conversion, removing the need to reposition nodes during AST expansion. With this change, we get the following AST instead:

```
catenation, sub -1, 0 tags
  catenation, sub 0, 0 tags
    catenation, sub -1, 0 tags
      assertions: bol 
      iteration {0, -1}, sub -1, 0 tags, greedy
        catenation, sub 1, 0 tags
          iteration {0, 1}, sub -1, 0 tags, greedy
            catenation, sub 2, 0 tags
              literal (a, a) (97, 97), pos 0, sub -1, 0 tags
              union, sub -1, 0 tags
                literal empty
                catenation, sub -1, 0 tags
                  literal (a, a) (97, 97), pos 1, sub -1, 0 tags
                  union, sub -1, 0 tags
                    literal empty
                    literal (a, a) (97, 97), pos 2, sub -1, 0 tags
          literal (x, x) (120, 120), pos 3, sub -1, 0 tags
    literal (y, y) (121, 121), pos 4, sub -1, 0 tags
  literal (, ) (0, 0), pos 5, sub -1, 0 tags
```

This PR adds test cases which trigger the bug and implements the solution described above.