### PR TITLE
Fix bug when building without alloca

### DIFF
--- a/lib/regexec.c
+++ b/lib/regexec.c
@@ -161,13 +161,15 @@ tre_match(const tre_tnfa_t *tnfa, const void *string, size_t len,
 	{
 	  const tre_str_source *source = string;
 	  if (source->rewind == NULL || source->compare == NULL)
-	    /* The backtracking matcher requires rewind and compare
-	       capabilities from the input stream. */
+	    {
+	      /* The backtracking matcher requires rewind and compare
+		 capabilities from the input stream. */
 #ifndef TRE_USE_ALLOCA
-	    if (tags)
-	      xfree(tags);
+	      if (tags)
+		xfree(tags);
 #endif /* !TRE_USE_ALLOCA */
-	    return REG_BADPAT;
+	      return REG_BADPAT;
+	    }
 	}
       status = tre_tnfa_run_backtrack(tnfa, string, (int)len, type,
 				      tags, eflags, &eo);


### PR DESCRIPTION
In `tre_match()`, there is a spot where we check if the provided source is capable of rewinding, and return if it isn't.  Due to missing braces, that return becomes unconditional when `TRE_USE_ALLOCA` is false.  As a result, calling `regexec()` with a regex that includes back references always fails with `REG_BADPAT`.