### PR TITLE
Sanitize tre.pc.in

### DIFF
--- a/tre.pc.in
+++ b/tre.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: TRE
 Description: TRE regexp matching library
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -ltre @LDFLAGS@ @LIBINTL@ @LIBS@
-Cflags: -I${includedir} @CPPFLAGS@
+Libs: -L${libdir} -ltre
+Cflags: -I${includedir}


### PR DESCRIPTION
Hello.

The Debian package for `tre` had a tre.pc file which contained the different compiler flags that were used to build the `tre` package itself. Since we don't want that to be propagated to other packages, the following patch was applied to the Debian package.

Thanks.