### PR TITLE
Add missing \ to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ SUBDIRS = local_includes lib $(agrep_dirs) tests utils po m4
 
 EXTRA_DIST = \
 	LICENSE \
-	win32/tre-config.h
+	win32/tre-config.h \
 	win32/config.h \
 	win32/tre.vcxproj \
 	win32/tre.sln \


### PR DESCRIPTION
This silently dropped python files from the dist.

Bug: https://bugs.gentoo.org/949527
Fixes: 13759f228dbb5f34b51109ed875ba5f14e6b9a50

<details>
<summary>Diffoscope output of the dist before/after</summary>

Mostly noise from different times, but the effect of the change can be seen.
```
$ diffoscope ../tre-0.9.0.tar.gz tre-0.9.0.tar.gz 
--- ../tre-0.9.0.tar.gz
+++ tre-0.9.0.tar.gz
├── tre-0.9.0.tar
│ ├── file list
│ │ @@ -1,143 +1,151 @@
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:54.000000 tre-0.9.0/m4/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/m4/
│ │  -rw-r--r--   0     1000     1000     1323 2025-02-11 15:23:07.000000 tre-0.9.0/m4/ax_check_funcs_comp.m4
│ │  -rw-r--r--   0     1000     1000     2129 2025-02-11 15:23:07.000000 tre-0.9.0/m4/ax_check_sign.m4
│ │  -rw-r--r--   0     1000     1000     1817 2025-02-11 15:23:07.000000 tre-0.9.0/m4/ax_decl_wchar_max.m4
│ │ --rw-r--r--   0     1000     1000    14712 2025-02-11 15:26:37.000000 tre-0.9.0/m4/gettext.m4
│ │ --rw-r--r--   0     1000     1000     6123 2025-02-11 15:26:37.000000 tre-0.9.0/m4/iconv.m4
│ │ --rw-r--r--   0     1000     1000     2421 2025-02-11 15:26:37.000000 tre-0.9.0/m4/intlmacosx.m4
│ │ --rw-r--r--   0     1000     1000     3417 2025-02-11 15:26:37.000000 tre-0.9.0/m4/lib-ld.m4
│ │ --rw-r--r--   0     1000     1000    29741 2025-02-11 15:26:37.000000 tre-0.9.0/m4/lib-link.m4
│ │ --rw-r--r--   0     1000     1000     6686 2025-02-11 15:26:37.000000 tre-0.9.0/m4/lib-prefix.m4
│ │ --rw-r--r--   0     1000     1000   311450 2025-02-11 15:26:40.000000 tre-0.9.0/m4/libtool.m4
│ │ --rw-r--r--   0     1000     1000    15441 2025-02-11 15:26:40.000000 tre-0.9.0/m4/ltoptions.m4
│ │ --rw-r--r--   0     1000     1000     4395 2025-02-11 15:26:40.000000 tre-0.9.0/m4/ltsugar.m4
│ │ --rw-r--r--   0     1000     1000      714 2025-02-11 15:26:40.000000 tre-0.9.0/m4/ltversion.m4
│ │ --rw-r--r--   0     1000     1000     6151 2025-02-11 15:26:40.000000 tre-0.9.0/m4/lt~obsolete.m4
│ │ --rw-r--r--   0     1000     1000     1206 2025-02-11 15:26:37.000000 tre-0.9.0/m4/nls.m4
│ │ --rw-r--r--   0     1000     1000    18822 2025-02-11 15:26:37.000000 tre-0.9.0/m4/po.m4
│ │ --rw-r--r--   0     1000     1000     2920 2025-02-11 15:26:37.000000 tre-0.9.0/m4/progtest.m4
│ │ +-rw-r--r--   0     1000     1000    14712 2025-02-11 15:39:37.000000 tre-0.9.0/m4/gettext.m4
│ │ +-rw-r--r--   0     1000     1000     6123 2025-02-11 15:39:37.000000 tre-0.9.0/m4/iconv.m4
│ │ +-rw-r--r--   0     1000     1000     2421 2025-02-11 15:39:37.000000 tre-0.9.0/m4/intlmacosx.m4
│ │ +-rw-r--r--   0     1000     1000     3417 2025-02-11 15:39:37.000000 tre-0.9.0/m4/lib-ld.m4
│ │ +-rw-r--r--   0     1000     1000    29741 2025-02-11 15:39:37.000000 tre-0.9.0/m4/lib-link.m4
│ │ +-rw-r--r--   0     1000     1000     6686 2025-02-11 15:39:37.000000 tre-0.9.0/m4/lib-prefix.m4
│ │ +-rw-r--r--   0     1000     1000   311450 2025-02-11 15:44:33.000000 tre-0.9.0/m4/libtool.m4
│ │ +-rw-r--r--   0     1000     1000    15441 2025-02-11 15:44:33.000000 tre-0.9.0/m4/ltoptions.m4
│ │ +-rw-r--r--   0     1000     1000     4395 2025-02-11 15:44:33.000000 tre-0.9.0/m4/ltsugar.m4
│ │ +-rw-r--r--   0     1000     1000      714 2025-02-11 15:44:33.000000 tre-0.9.0/m4/ltversion.m4
│ │ +-rw-r--r--   0     1000     1000     6151 2025-02-11 15:44:33.000000 tre-0.9.0/m4/lt~obsolete.m4
│ │ +-rw-r--r--   0     1000     1000     1206 2025-02-11 15:39:37.000000 tre-0.9.0/m4/nls.m4
│ │ +-rw-r--r--   0     1000     1000    18822 2025-02-11 15:39:37.000000 tre-0.9.0/m4/po.m4
│ │ +-rw-r--r--   0     1000     1000     2920 2025-02-11 15:39:37.000000 tre-0.9.0/m4/progtest.m4
│ │  -rw-r--r--   0     1000     1000     4869 2025-02-11 15:23:07.000000 tre-0.9.0/m4/vl_prog_cc_warnings.m4
│ │  -rw-r--r--   0     1000     1000      109 2025-02-11 15:23:07.000000 tre-0.9.0/m4/Makefile.am
│ │ --rw-r--r--   0     1000     1000    13556 2025-02-11 15:26:42.000000 tre-0.9.0/m4/Makefile.in
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/python/
│ │ +-rw-r--r--   0     1000     1000    13556 2025-02-11 15:44:35.000000 tre-0.9.0/m4/Makefile.in
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:43.000000 tre-0.9.0/python/
│ │  -rw-r--r--   0     1000     1000     1407 2025-02-11 15:23:07.000000 tre-0.9.0/python/setup.py.in
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/utils/
│ │ --rwxr-xr-x   0     1000     1000     7621 2025-02-11 15:26:42.000000 tre-0.9.0/utils/compile
│ │ --rwxr-xr-x   0     1000     1000    50743 2025-02-11 15:26:42.000000 tre-0.9.0/utils/config.guess
│ │ --rwxr-xr-x   0     1000     1000    18343 2025-02-11 15:26:37.000000 tre-0.9.0/utils/config.rpath
│ │ --rwxr-xr-x   0     1000     1000    39713 2025-02-11 15:26:42.000000 tre-0.9.0/utils/config.sub
│ │ --rwxr-xr-x   0     1000     1000    15437 2025-02-11 15:26:42.000000 tre-0.9.0/utils/install-sh
│ │ --rw-r--r--   0     1000     1000   337863 2025-02-11 15:26:40.000000 tre-0.9.0/utils/ltmain.sh
│ │ --rwxr-xr-x   0     1000     1000     7728 2025-02-11 15:26:42.000000 tre-0.9.0/utils/missing
│ │ --rwxr-xr-x   0     1000     1000    23695 2025-02-11 15:26:42.000000 tre-0.9.0/utils/depcomp
│ │ --rwxr-xr-x   0     1000     1000     5215 2025-02-11 15:26:42.000000 tre-0.9.0/utils/test-driver
│ │ +-rw-r--r--   0     1000     1000    26084 2025-02-11 15:23:07.000000 tre-0.9.0/python/tre-python.c
│ │ +-rw-r--r--   0     1000     1000     1399 2025-02-11 15:44:41.000000 tre-0.9.0/python/setup.py
│ │ +-rw-r--r--   0     1000     1000     6751 2025-02-11 15:23:07.000000 tre-0.9.0/python/example.py
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/utils/
│ │ +-rwxr-xr-x   0     1000     1000     7621 2025-02-11 15:44:35.000000 tre-0.9.0/utils/compile
│ │ +-rwxr-xr-x   0     1000     1000    50743 2025-02-11 15:44:35.000000 tre-0.9.0/utils/config.guess
│ │ +-rwxr-xr-x   0     1000     1000    18343 2025-02-11 15:39:37.000000 tre-0.9.0/utils/config.rpath
│ │ +-rwxr-xr-x   0     1000     1000    39713 2025-02-11 15:44:35.000000 tre-0.9.0/utils/config.sub
│ │ +-rwxr-xr-x   0     1000     1000    15437 2025-02-11 15:44:35.000000 tre-0.9.0/utils/install-sh
│ │ +-rw-r--r--   0     1000     1000   337863 2025-02-11 15:44:33.000000 tre-0.9.0/utils/ltmain.sh
│ │ +-rwxr-xr-x   0     1000     1000     7728 2025-02-11 15:44:35.000000 tre-0.9.0/utils/missing
│ │ +-rwxr-xr-x   0     1000     1000    23695 2025-02-11 15:44:35.000000 tre-0.9.0/utils/depcomp
│ │ +-rwxr-xr-x   0     1000     1000     5215 2025-02-11 15:44:35.000000 tre-0.9.0/utils/test-driver
│ │  -rw-r--r--   0     1000     1000       43 2025-02-11 15:23:07.000000 tre-0.9.0/utils/Makefile.am
│ │ --rw-r--r--   0     1000     1000    13584 2025-02-11 15:26:43.000000 tre-0.9.0/utils/Makefile.in
│ │ +-rw-r--r--   0     1000     1000    13584 2025-02-11 15:44:35.000000 tre-0.9.0/utils/Makefile.in
│ │  -rwxr-xr-x   0     1000     1000      569 2025-02-11 15:23:07.000000 tre-0.9.0/utils/autogen.sh
│ │  -rwxr-xr-x   0     1000     1000      627 2025-02-11 15:23:07.000000 tre-0.9.0/utils/build-rpm.sh
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/win32/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:43.000000 tre-0.9.0/win32/
│ │  -rw-r--r--   0     1000     1000     5257 2025-02-11 15:23:07.000000 tre-0.9.0/win32/config.h.in
│ │  -rw-r--r--   0     1000     1000     1364 2025-02-11 15:23:07.000000 tre-0.9.0/win32/tre-config.h.in
│ │ --rw-r--r--   0     1000     1000     1314 2025-02-11 15:26:52.000000 tre-0.9.0/win32/tre-config.h
│ │ --rw-r--r--   0     1000     1000      511 2025-02-11 15:23:07.000000 tre-0.9.0/Makefile.am
│ │ --rwxr-xr-x   0     1000     1000   610847 2025-02-11 15:26:42.000000 tre-0.9.0/configure
│ │ +-rw-r--r--   0     1000     1000     1314 2025-02-11 15:44:41.000000 tre-0.9.0/win32/tre-config.h
│ │ +-rw-r--r--   0     1000     1000     5207 2025-02-11 15:44:41.000000 tre-0.9.0/win32/config.h
│ │ +-rw-r--r--   0     1000     1000     8897 2025-02-11 15:23:07.000000 tre-0.9.0/win32/tre.vcxproj
│ │ +-rw-r--r--   0     1000     1000     2977 2025-02-11 15:23:07.000000 tre-0.9.0/win32/tre.sln
│ │ +-rw-r--r--   0     1000     1000     7236 2025-02-11 15:23:07.000000 tre-0.9.0/win32/retest.vcxproj
│ │ +-rw-r--r--   0     1000     1000     7190 2025-02-11 15:23:07.000000 tre-0.9.0/win32/test-str-source.vcxproj
│ │ +-rw-r--r--   0     1000     1000      513 2025-02-11 15:41:49.000000 tre-0.9.0/Makefile.am
│ │ +-rwxr-xr-x   0     1000     1000   610847 2025-02-11 15:44:35.000000 tre-0.9.0/configure
│ │  -rw-r--r--   0     1000     1000    16331 2025-02-11 15:23:07.000000 tre-0.9.0/configure.ac
│ │ --rw-r--r--   0     1000     1000    50466 2025-02-11 15:26:41.000000 tre-0.9.0/aclocal.m4
│ │ --rw-r--r--   0     1000     1000    31000 2025-02-11 15:26:42.000000 tre-0.9.0/Makefile.in
│ │ --rw-r--r--   0     1000     1000    10406 2025-02-11 15:26:42.000000 tre-0.9.0/config.h.in
│ │ +-rw-r--r--   0     1000     1000    50466 2025-02-11 15:44:34.000000 tre-0.9.0/aclocal.m4
│ │ +-rw-r--r--   0     1000     1000    31002 2025-02-11 15:44:35.000000 tre-0.9.0/Makefile.in
│ │ +-rw-r--r--   0     1000     1000    10406 2025-02-11 15:44:35.000000 tre-0.9.0/config.h.in
│ │  -rw-r--r--   0     1000     1000      247 2025-02-11 15:23:07.000000 tre-0.9.0/tre.pc.in
│ │  -rw-r--r--   0     1000     1000     2905 2025-02-11 15:23:07.000000 tre-0.9.0/tre.spec.in
│ │ --rw-r--r--   0     1000     1000    76502 2025-02-11 15:26:37.000000 tre-0.9.0/ABOUT-NLS
│ │ +-rw-r--r--   0     1000     1000    76502 2025-02-11 15:39:37.000000 tre-0.9.0/ABOUT-NLS
│ │  -rw-r--r--   0     1000     1000       28 2025-02-11 15:23:07.000000 tre-0.9.0/AUTHORS
│ │  -rw-r--r--   0     1000     1000     7883 2025-02-11 15:23:07.000000 tre-0.9.0/NEWS
│ │  -rw-r--r--   0     1000     1000     9657 2025-02-11 15:23:07.000000 tre-0.9.0/README.md
│ │  -rw-r--r--   0     1000     1000      930 2025-02-11 15:23:07.000000 tre-0.9.0/THANKS
│ │  -rw-r--r--   0     1000     1000     1628 2025-02-11 15:23:07.000000 tre-0.9.0/TODO
│ │  -rw-r--r--   0     1000     1000     1479 2025-02-11 15:23:07.000000 tre-0.9.0/LICENSE
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/local_includes/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:43.000000 tre-0.9.0/local_includes/
│ │  -rw-r--r--   0     1000     1000       82 2025-02-11 15:23:07.000000 tre-0.9.0/local_includes/Makefile.am
│ │  -rw-r--r--   0     1000     1000    10475 2025-02-11 15:23:07.000000 tre-0.9.0/local_includes/tre.h
│ │  -rw-r--r--   0     1000     1000     1464 2025-02-11 15:23:07.000000 tre-0.9.0/local_includes/regex.h
│ │ --rw-r--r--   0     1000     1000     1357 2025-02-11 15:26:52.000000 tre-0.9.0/local_includes/tre-config.h
│ │ --rw-r--r--   0     1000     1000    18377 2025-02-11 15:26:42.000000 tre-0.9.0/local_includes/Makefile.in
│ │ +-rw-r--r--   0     1000     1000     1357 2025-02-11 15:44:41.000000 tre-0.9.0/local_includes/tre-config.h
│ │ +-rw-r--r--   0     1000     1000    18377 2025-02-11 15:44:35.000000 tre-0.9.0/local_includes/Makefile.in
│ │  -rw-r--r--   0     1000     1000     1218 2025-02-11 15:23:07.000000 tre-0.9.0/local_includes/tre-config.h.in
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/lib/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/lib/
│ │  -rw-r--r--   0     1000     1000      638 2025-02-11 15:23:07.000000 tre-0.9.0/lib/Makefile.am
│ │  -rw-r--r--   0     1000     1000     3464 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-ast.h
│ │  -rw-r--r--   0     1000     1000      445 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-compile.h
│ │  -rw-r--r--   0     1000     1000     7821 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-internal.h
│ │  -rw-r--r--   0     1000     1000     6843 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-match-utils.h
│ │  -rw-r--r--   0     1000     1000     1823 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-mem.h
│ │  -rw-r--r--   0     1000     1000     1416 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-parse.h
│ │  -rw-r--r--   0     1000     1000     2256 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-stack.h
│ │  -rw-r--r--   0     1000     1000     2394 2025-02-11 15:23:07.000000 tre-0.9.0/lib/xmalloc.h
│ │ --rw-r--r--   0     1000     1000    24661 2025-02-11 15:26:42.000000 tre-0.9.0/lib/Makefile.in
│ │ +-rw-r--r--   0     1000     1000    24661 2025-02-11 15:44:35.000000 tre-0.9.0/lib/Makefile.in
│ │  -rw-r--r--   0     1000     1000     2755 2025-02-11 15:23:07.000000 tre-0.9.0/lib/README
│ │  -rw-r--r--   0     1000     1000     5127 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-ast.c
│ │  -rw-r--r--   0     1000     1000    59978 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-compile.c
│ │  -rw-r--r--   0     1000     1000    17866 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-match-backtrack.c
│ │  -rw-r--r--   0     1000     1000    12811 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-match-parallel.c
│ │  -rw-r--r--   0     1000     1000     3190 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-mem.c
│ │  -rw-r--r--   0     1000     1000    44619 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-parse.c
│ │  -rw-r--r--   0     1000     1000     2384 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-stack.c
│ │  -rw-r--r--   0     1000     1000     3969 2025-02-11 15:23:07.000000 tre-0.9.0/lib/regcomp.c
│ │  -rw-r--r--   0     1000     1000    10190 2025-02-11 15:23:07.000000 tre-0.9.0/lib/regexec.c
│ │  -rw-r--r--   0     1000     1000     2410 2025-02-11 15:23:07.000000 tre-0.9.0/lib/regerror.c
│ │  -rw-r--r--   0     1000     1000    23141 2025-02-11 15:23:07.000000 tre-0.9.0/lib/tre-match-approx.c
│ │  -rw-r--r--   0     1000     1000     6943 2025-02-11 15:23:07.000000 tre-0.9.0/lib/xmalloc.c
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/src/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/src/
│ │  -rw-r--r--   0     1000     1000      350 2025-02-11 15:23:07.000000 tre-0.9.0/src/Makefile.am
│ │ --rw-r--r--   0     1000     1000    23051 2025-02-11 15:26:42.000000 tre-0.9.0/src/Makefile.in
│ │ +-rw-r--r--   0     1000     1000    23051 2025-02-11 15:44:35.000000 tre-0.9.0/src/Makefile.in
│ │  -rw-r--r--   0     1000     1000    22189 2025-02-11 15:23:07.000000 tre-0.9.0/src/agrep.c
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/doc/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/doc/
│ │  -rw-r--r--   0     1000     1000      157 2025-02-11 15:23:07.000000 tre-0.9.0/doc/Makefile.am
│ │ --rw-r--r--   0     1000     1000    16809 2025-02-11 15:26:42.000000 tre-0.9.0/doc/Makefile.in
│ │ +-rw-r--r--   0     1000     1000    16809 2025-02-11 15:44:35.000000 tre-0.9.0/doc/Makefile.in
│ │  -rw-r--r--   0     1000     1000     6141 2025-02-11 15:23:07.000000 tre-0.9.0/doc/agrep.1.in
│ │  -rw-r--r--   0     1000     1000    31115 2025-02-11 15:23:07.000000 tre-0.9.0/doc/tre-api.html
│ │  -rw-r--r--   0     1000     1000    14917 2025-02-11 15:23:07.000000 tre-0.9.0/doc/tre-syntax.html
│ │  -rw-r--r--   0     1000     1000      376 2025-02-11 15:23:07.000000 tre-0.9.0/doc/default.css
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/tests/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/tests/
│ │  -rw-r--r--   0     1000     1000     1859 2025-02-11 15:23:07.000000 tre-0.9.0/tests/Makefile.am
│ │ --rw-r--r--   0     1000     1000    70563 2025-02-11 15:26:42.000000 tre-0.9.0/tests/Makefile.in
│ │ +-rw-r--r--   0     1000     1000    70563 2025-02-11 15:44:35.000000 tre-0.9.0/tests/Makefile.in
│ │  -rw-r--r--   0     1000     1000    10484 2025-02-11 15:23:07.000000 tre-0.9.0/tests/bench.c
│ │  -rw-r--r--   0     1000     1000     1379 2025-02-11 15:23:07.000000 tre-0.9.0/tests/randtest.c
│ │  -rw-r--r--   0     1000     1000    64344 2025-02-11 15:23:07.000000 tre-0.9.0/tests/retest.c
│ │  -rw-r--r--   0     1000     1000     4467 2025-02-11 15:23:07.000000 tre-0.9.0/tests/test-str-source.c
│ │  -rwxr-xr-x   0     1000     1000      608 2025-02-11 15:23:07.000000 tre-0.9.0/tests/build-tests.sh
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:53.000000 tre-0.9.0/tests/agrep/
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/tests/agrep/
│ │  -rw-r--r--   0     1000     1000      295 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/Makefile.am
│ │ --rw-r--r--   0     1000     1000    28926 2025-02-11 15:26:43.000000 tre-0.9.0/tests/agrep/Makefile.in
│ │ +-rw-r--r--   0     1000     1000    28926 2025-02-11 15:44:35.000000 tre-0.9.0/tests/agrep/Makefile.in
│ │  -rwxr-xr-x   0     1000     1000     3391 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/run-tests.sh
│ │  -rw-r--r--   0     1000     1000       92 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/basic.args
│ │  -rw-r--r--   0     1000     1000      234 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/delimiters.args
│ │  -rw-r--r--   0     1000     1000      204 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/exitstatus.args
│ │  -rw-r--r--   0     1000     1000      256 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/records.args
│ │  -rw-r--r--   0     1000     1000    13482 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/basic.ok
│ │  -rw-r--r--   0     1000     1000    11004 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/delimiters.ok
│ │  -rw-r--r--   0     1000     1000    17074 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/exitstatus.ok
│ │  -rw-r--r--   0     1000     1000    45718 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/records.ok
│ │  -rw-r--r--   0     1000     1000      290 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/basic.input
│ │  -rw-r--r--   0     1000     1000       47 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/delimiters.input
│ │  -rw-r--r--   0     1000     1000       48 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/exitstatus.input
│ │  -rw-r--r--   0     1000     1000     1340 2025-02-11 15:23:07.000000 tre-0.9.0/tests/agrep/records.input
│ │ -drwxr-xr-x   0     1000     1000        0 2025-02-11 15:26:54.000000 tre-0.9.0/po/
│ │ --rw-r--r--   0     1000     1000    15188 2025-02-11 15:26:37.000000 tre-0.9.0/po/Makefile.in.in
│ │ --rw-r--r--   0     1000     1000      432 2025-02-11 15:26:37.000000 tre-0.9.0/po/remove-potcdate.sin
│ │ --rw-r--r--   0     1000     1000      153 2025-02-11 15:26:37.000000 tre-0.9.0/po/quot.sed
│ │ --rw-r--r--   0     1000     1000      217 2025-02-11 15:26:37.000000 tre-0.9.0/po/boldquot.sed
│ │ --rw-r--r--   0     1000     1000     1203 2025-02-11 15:26:37.000000 tre-0.9.0/po/en@quot.header
│ │ --rw-r--r--   0     1000     1000     1337 2025-02-11 15:26:37.000000 tre-0.9.0/po/en@boldquot.header
│ │ --rw-r--r--   0     1000     1000      672 2025-02-11 15:26:37.000000 tre-0.9.0/po/insert-header.sin
│ │ --rw-r--r--   0     1000     1000     1790 2025-02-11 15:26:37.000000 tre-0.9.0/po/Rules-quot
│ │ +drwxr-xr-x   0     1000     1000        0 2025-02-11 15:44:44.000000 tre-0.9.0/po/
│ │ +-rw-r--r--   0     1000     1000    15188 2025-02-11 15:39:37.000000 tre-0.9.0/po/Makefile.in.in
│ │ +-rw-r--r--   0     1000     1000      432 2025-02-11 15:39:37.000000 tre-0.9.0/po/remove-potcdate.sin
│ │ +-rw-r--r--   0     1000     1000      153 2025-02-11 15:39:37.000000 tre-0.9.0/po/quot.sed
│ │ +-rw-r--r--   0     1000     1000      217 2025-02-11 15:39:37.000000 tre-0.9.0/po/boldquot.sed
│ │ +-rw-r--r--   0     1000     1000     1203 2025-02-11 15:39:37.000000 tre-0.9.0/po/en@quot.header
│ │ +-rw-r--r--   0     1000     1000     1337 2025-02-11 15:39:37.000000 tre-0.9.0/po/en@boldquot.header
│ │ +-rw-r--r--   0     1000     1000      672 2025-02-11 15:39:37.000000 tre-0.9.0/po/insert-header.sin
│ │ +-rw-r--r--   0     1000     1000     1790 2025-02-11 15:39:37.000000 tre-0.9.0/po/Rules-quot
│ │  -rw-r--r--   0     1000     1000     1823 2025-02-11 15:23:07.000000 tre-0.9.0/po/Makevars
│ │  -rw-r--r--   0     1000     1000      115 2025-02-11 15:23:07.000000 tre-0.9.0/po/POTFILES.in
│ │ --rw-r--r--   0     1000     1000     9521 2025-02-11 15:26:54.000000 tre-0.9.0/po/fi.po
│ │ --rw-r--r--   0     1000     1000     8905 2025-02-11 15:26:54.000000 tre-0.9.0/po/sv.po
│ │ --rw-r--r--   0     1000     1000     6034 2025-02-11 15:26:54.000000 tre-0.9.0/po/zh_CN.po
│ │ --rw-r--r--   0     1000     1000     4039 2025-02-11 15:26:54.000000 tre-0.9.0/po/fi.gmo
│ │ --rw-r--r--   0     1000     1000     3563 2025-02-11 15:26:54.000000 tre-0.9.0/po/sv.gmo
│ │ --rw-r--r--   0     1000     1000     1969 2025-02-11 15:26:54.000000 tre-0.9.0/po/zh_CN.gmo
│ │ --rw-r--r--   0     1000     1000     5459 2025-02-11 15:26:54.000000 tre-0.9.0/po/tre.pot
│ │ --rw-r--r--   0     1000     1000       10 2025-02-11 15:26:54.000000 tre-0.9.0/po/stamp-po
│ │ +-rw-r--r--   0     1000     1000     9521 2025-02-11 15:44:44.000000 tre-0.9.0/po/fi.po
│ │ +-rw-r--r--   0     1000     1000     8905 2025-02-11 15:44:44.000000 tre-0.9.0/po/sv.po
│ │ +-rw-r--r--   0     1000     1000     6034 2025-02-11 15:44:44.000000 tre-0.9.0/po/zh_CN.po
│ │ +-rw-r--r--   0     1000     1000     4039 2025-02-11 15:44:44.000000 tre-0.9.0/po/fi.gmo
│ │ +-rw-r--r--   0     1000     1000     3563 2025-02-11 15:44:44.000000 tre-0.9.0/po/sv.gmo
│ │ +-rw-r--r--   0     1000     1000     1969 2025-02-11 15:44:44.000000 tre-0.9.0/po/zh_CN.gmo
│ │ +-rw-r--r--   0     1000     1000     5459 2025-02-11 15:44:44.000000 tre-0.9.0/po/tre.pot
│ │ +-rw-r--r--   0     1000     1000       10 2025-02-11 15:44:44.000000 tre-0.9.0/po/stamp-po
│ │  -rw-r--r--   0     1000     1000       42 2025-02-11 15:23:07.000000 tre-0.9.0/po/LINGUAS
│ ├── tre-0.9.0/Makefile.am
│ │ @@ -6,15 +6,15 @@
│ │  agrep_dirs =
│ │  endif
│ │  
│ │  SUBDIRS = local_includes lib $(agrep_dirs) tests utils po m4
│ │  
│ │  EXTRA_DIST = \
│ │     LICENSE \
│ │ -   win32/tre-config.h
│ │ +   win32/tre-config.h \
│ │     win32/config.h \
│ │     win32/tre.vcxproj \
│ │     win32/tre.sln \
│ │     win32/retest.vcxproj \
│ │     win32/test-str-source.vcxproj \
│ │     python/tre-python.c \
│ │     python/setup.py \
│ ├── tre-0.9.0/Makefile.in
│ │ @@ -404,15 +404,23 @@
│ │  top_builddir = @top_builddir@
│ │  top_srcdir = @top_srcdir@
│ │  @TRE_AGREP_FALSE@agrep_dirs = 
│ │  @TRE_AGREP_TRUE@agrep_dirs = src doc
│ │  SUBDIRS = local_includes lib $(agrep_dirs) tests utils po m4
│ │  EXTRA_DIST = \
│ │     LICENSE \
│ │ -   win32/tre-config.h
│ │ +   win32/tre-config.h \
│ │ +   win32/config.h \
│ │ +   win32/tre.vcxproj \
│ │ +   win32/tre.sln \
│ │ +   win32/retest.vcxproj \
│ │ +   win32/test-str-source.vcxproj \
│ │ +   python/tre-python.c \
│ │ +   python/setup.py \
│ │ +   python/example.py
│ │  
│ │  ACLOCAL_AMFLAGS = -I m4
│ │  AC_CONFIG_AUX_DIR = utils
│ │  pkgconfigdir = $(libdir)/pkgconfig
│ │  pkgconfig_DATA = tre.pc
│ │  all: config.h
│ │     $(MAKE) $(AM_MAKEFLAGS) all-recursive
│ │ @@ -935,22 +943,14 @@
│ │     installdirs-am maintainer-clean maintainer-clean-generic \
│ │     mostlyclean mostlyclean-generic mostlyclean-libtool pdf pdf-am \
│ │     ps ps-am tags tags-am uninstall uninstall-am \
│ │     uninstall-pkgconfigDATA
│ │  
│ │  .PRECIOUS: Makefile
│ │  
│ │ -   win32/config.h \
│ │ -   win32/tre.vcxproj \
│ │ -   win32/tre.sln \
│ │ -   win32/retest.vcxproj \
│ │ -   win32/test-str-source.vcxproj \
│ │ -   python/tre-python.c \
│ │ -   python/setup.py \
│ │ -   python/example.py
│ │  
│ │  # Tell versions [3.59,3.63) of GNU make to not export all variables.
│ │  # Otherwise a system limit (for SysV at least) may be exceeded.
│ │  .NOEXPORT:
│ │  
│ │  # Tell GNU make to disable its built-in pattern rules.
│ │  %:: %,v
│ ├── tre-0.9.0/po/fi.po
│ │ @@ -1,15 +1,15 @@
│ │  # Finnish translations for TRE package.
│ │  # This file is distributed under the same license as the TRE package.
│ │  #
│ │  msgid ""
│ │  msgstr ""
│ │  "Project-Id-Version: TRE 0.7.4\n"
│ │  "Report-Msgid-Bugs-To: tre-general@lists.laurikari.net\n"
│ │ -"POT-Creation-Date: 2025-02-11 17:26+0200\n"
│ │ +"POT-Creation-Date: 2025-02-11 17:44+0200\n"
│ │  "PO-Revision-Date: 2002-07-29 23:46+0300\n"
│ │  "Last-Translator: Ville Laurikari <vl@iki.fi>\n"
│ │  "Language-Team: Finnish <translation-team-fi@lists.sourceforge.net>\n"
│ │  "Language: fi\n"
│ │  "MIME-Version: 1.0\n"
│ │  "Content-Type: text/plain; charset=ISO-8859-1\n"
│ │  "Content-Transfer-Encoding: 8bit\n"
│ ├── tre-0.9.0/po/sv.po
│ │ @@ -2,15 +2,15 @@
│ │  # This file is distributed under the same license as the TRE package.
│ │  # Daniel Nylander <po@danielnylander.se>, 2006.
│ │  #
│ │  msgid ""
│ │  msgstr ""
│ │  "Project-Id-Version: tre\n"
│ │  "Report-Msgid-Bugs-To: tre-general@lists.laurikari.net\n"
│ │ -"POT-Creation-Date: 2025-02-11 17:26+0200\n"
│ │ +"POT-Creation-Date: 2025-02-11 17:44+0200\n"
│ │  "PO-Revision-Date: 2006-05-23 21:27+0100\n"
│ │  "Last-Translator: Daniel Nylander <po@danielnylander.se>\n"
│ │  "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
│ │  "Language: sv\n"
│ │  "MIME-Version: 1.0\n"
│ │  "Content-Type: text/plain; charset=utf-8\n"
│ │  "Content-Transfer-Encoding: 8bit\n"
│ ├── tre-0.9.0/po/zh_CN.po
│ │ @@ -3,15 +3,15 @@
│ │  # This file is distributed under the same license as the tre package.
│ │  # Mingye Wang <arthur200126@gmail.com>, 2021.
│ │  #
│ │  msgid ""
│ │  msgstr ""
│ │  "Project-Id-Version: tre 0.8.0\n"
│ │  "Report-Msgid-Bugs-To: tre-general@lists.laurikari.net\n"
│ │ -"POT-Creation-Date: 2025-02-11 17:26+0200\n"
│ │ +"POT-Creation-Date: 2025-02-11 17:44+0200\n"
│ │  "PO-Revision-Date: 2021-05-19 16:01+0800\n"
│ │  "Last-Translator: Mingye Wang <arthur200126@gmail.com>\n"
│ │  "Language-Team: \n"
│ │  "Language: zh_CN\n"
│ │  "MIME-Version: 1.0\n"
│ │  "Content-Type: text/plain; charset=UTF-8\n"
│ │  "Content-Transfer-Encoding: 8bit\n"
│ ├── tre-0.9.0/po/tre.pot
│ │ @@ -4,15 +4,15 @@
│ │  # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
│ │  #
│ │  #, fuzzy
│ │  msgid ""
│ │  msgstr ""
│ │  "Project-Id-Version: tre 0.9.0\n"
│ │  "Report-Msgid-Bugs-To: tre-general@lists.laurikari.net\n"
│ │ -"POT-Creation-Date: 2025-02-11 17:26+0200\n"
│ │ +"POT-Creation-Date: 2025-02-11 17:44+0200\n"
│ │  "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
│ │  "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
│ │  "Language-Team: LANGUAGE <LL@li.org>\n"
│ │  "Language: \n"
│ │  "MIME-Version: 1.0\n"
│ │  "Content-Type: text/plain; charset=CHARSET\n"
│ │  "Content-Transfer-Encoding: 8bit\n"
```

</details>