### PR TITLE
Support octal escapes as well as hexadecimal.

### DIFF
--- a/doc/tre-syntax.html
+++ b/doc/tre-syntax.html
@@ -337,7 +337,9 @@ An assertion-character can be any of the following:
 <tr><td>
 <pre>
 <i>literal</i> ::= <i>ordinary-character</i>
+        |   <b>"\o"</b> [<b>"0"</b>-<b>"7"</b> ]{0,3}
         |   <b>"\x"</b> [<b>"1"</b>-<b>"9"</b> <b>"a"-<b>"f"</b> <b>"A"</b>-<b>"F"</b>]{0,2}
+        |   <b>"\o{"</b> [<b>"0"</b>-<b>"7"</b> ]* <b>"}"</b>
         |   <b>"\x{"</b> [<b>"1"</b>-<b>"9"</b> <b>"a"-<b>"f"</b> <b>"A"</b>-<b>"F"</b>]* <b>"}"</b>
         |   <b>"\"</b> <i>character</i>
 </pre>
@@ -345,15 +347,15 @@ An assertion-character can be any of the following:
 </table>
 <p>
 A literal is either an ordinary character (a character that has no
-other significance in the context), an 8 bit hexadecimal encoded
-character (e.g. <tt>\x1B</tt>), a wide hexadecimal encoded character
-(e.g. <tt>\x{263a}</tt>), or an escaped character.  An escaped
-character is a <tt>\</tt> followed by any character, and matches that
-character.  Escaping can be used to match characters which have a
-special meaning in regexp syntax.  A <tt>\</tt> cannot be the last
-character of an ERE.  Escaping also allows you to include a few
-non-printable characters in the regular expression.  These special
-escape sequences include:
+other significance in the context), an 8 bit octal or hexadecimal
+encoded character (e.g. <tt>\x1B</tt>, <tt>\o33</tt>), a wide octal
+or hexadecimal encoded character (e.g. <tt>\x{263a}, \o{23072}</tt>), or an
+escaped character.  An escaped character is a <tt>\</tt> followed by
+any character, and matches that character.  Escaping can be used to
+match characters which have a special meaning in regexp syntax.
+A <tt>\</tt> cannot be the last character of an ERE.  Escaping also
+allows you to include a few non-printable characters in the regular
+expression.  These special escape sequences include:
 </p>
 
 <ul>

--- a/lib/tre-parse.c
+++ b/lib/tre-parse.c
@@ -1463,57 +1463,107 @@ tre_parse(tre_parse_ctx_t *ctx)
 					       ASSERT_AT_EOW);
 		  ctx->re++;
 		  break;
-		case L'x':
+		case L'o':
 		  ctx->re++;
-		  if (ctx->re[0] != CHAR_LBRACE && ctx->re < ctx->re_end)
+		  if (ctx->re[0] != CHAR_LBRACE)
 		    {
-		      /* 8 bit hex char. */
-		      char tmp[3] = {0, 0, 0};
-		      long val;
-		      DPRINT(("tre_parse:  8 bit hex: '%.*" STRF "'\n",
+		      unsigned long val = 0;
+		      unsigned int digit;
+		      DPRINT(("tre_parse:  8 bit oct: '%.*" STRF "'\n",
 			      REST(ctx->re - 2)));
-
-		      if (tre_isxdigit(ctx->re[0]) && ctx->re < ctx->re_end)
+		      while (ctx->re < ctx->re_end)
 			{
-			  tmp[0] = (char)ctx->re[0];
+			  if (ctx->re[0] >= L'0' && ctx->re[0] <= L'7')
+			    digit = ctx->re[0] - L'0';
+			  else
+			    break;
 			  ctx->re++;
+			  if (val > 0xff >> 3)
+			    return REG_EBRACE;
+			  val = val << 3 | digit;
 			}
-		      if (tre_isxdigit(ctx->re[0]) && ctx->re < ctx->re_end)
-			{
-			  tmp[1] = (char)ctx->re[0];
-			  ctx->re++;
-			}
-		      val = strtol(tmp, NULL, 16);
 		      result = tre_ast_new_literal(ctx->mem, (int)val, (int)val);
 		      break;
 		    }
-		  else if (ctx->re < ctx->re_end)
+		  else
 		    {
 		      /* Wide char. */
-		      char tmp[9]; /* max 8 hex digits + terminator */
-		      long val;
-		      size_t i = 0;
-		      ctx->re++;
-		      while (ctx->re_end - ctx->re >= 0)
+		      unsigned long val = 0;
+		      unsigned int digit;
+		      ctx->re++; // opening brace
+		      while (ctx->re < ctx->re_end)
 			{
 			  if (ctx->re[0] == CHAR_RBRACE)
 			    break;
-			  if (tre_isxdigit(ctx->re[0]) && i < sizeof(tmp) - 1)
-			    {
-			      tmp[i] = (char)ctx->re[0];
-			      i++;
-			      ctx->re++;
-			      continue;
-			    }
-			  return REG_EBRACE;
+			  else if (ctx->re[0] >= L'0' && ctx->re[0] <= L'7')
+			    digit = ctx->re[0] - L'0';
+			  else
+			    return REG_EBRACE;
+			  ctx->re++;
+			  if (val > 0xffffffffU >> 3)
+			    return REG_EBRACE;
+			  val = val << 3 | digit;
 			}
-		      ctx->re++;
-		      tmp[i] = 0;
-		      val = strtol(tmp, NULL, 16);
+		      ctx->re++; // closing brace
 		      result = tre_ast_new_literal(ctx->mem, (int)val, (int)val);
 		      break;
 		    }
-		  /*FALLTHROUGH*/
+		  break;
+		case L'x':
+		  ctx->re++;
+		  if (ctx->re[0] != CHAR_LBRACE)
+		    {
+		      /* 8 bit hex char. */
+		      unsigned long val = 0;
+		      unsigned int digit;
+		      DPRINT(("tre_parse:  8 bit hex: '%.*" STRF "'\n",
+			      REST(ctx->re - 2)));
+		      while (ctx->re < ctx->re_end)
+			{
+			  if (ctx->re[0] >= L'0' && ctx->re[0] <= L'9')
+			      digit = ctx->re[0] - L'0';
+			  else if (ctx->re[0] >= L'A' && ctx->re[0] <= L'F')
+			      digit = ctx->re[0] - L'A';
+			  else if (ctx->re[0] >= L'a' && ctx->re[0] <= L'f')
+			      digit = ctx->re[0] - L'a';
+			  else
+			    break;
+			  ctx->re++;
+			  if (val > 0xff >> 4)
+			    return REG_EBRACE;
+			  val = val << 4 | digit;
+			}
+		      result = tre_ast_new_literal(ctx->mem, (int)val, (int)val);
+		      break;
+		    }
+		  else
+		    {
+		      /* Wide char. */
+		      unsigned long val = 0;
+		      unsigned int digit;
+		      ctx->re++; // opening brace
+		      while (ctx->re < ctx->re_end)
+			{
+			  if (ctx->re[0] == CHAR_RBRACE)
+			    break;
+			  else if (ctx->re[0] >= L'0' && ctx->re[0] <= L'9')
+			      digit = ctx->re[0] - L'0';
+			  else if (ctx->re[0] >= L'A' && ctx->re[0] <= L'F')
+			      digit = ctx->re[0] - L'A';
+			  else if (ctx->re[0] >= L'a' && ctx->re[0] <= L'f')
+			      digit = ctx->re[0] - L'a';
+			  else
+			    return REG_EBRACE;
+			  ctx->re++;
+			  if (val > 0xffffffffU >> 4)
+			    return REG_EBRACE;
+			  val = val << 4 | digit;
+			}
+		      ctx->re++; // closing brace
+		      result = tre_ast_new_literal(ctx->mem, (int)val, (int)val);
+		      break;
+		    }
+		  break;
 
 		default:
 		  if (tre_isdigit(*ctx->re))

--- a/tests/retest.c
+++ b/tests/retest.c
@@ -1367,6 +1367,32 @@ main(int argc, char **argv)
   test_comp("\\t", REG_EXTENDED, 0);
   test_comp("\\e", REG_EXTENDED, 0);
 
+  /* Test the \o33 and \o{23072} extensions for specifying 8 bit and wide
+     characters in octal. */
+  test_comp("\\o101", REG_EXTENDED, 0);
+  test_exec("ABC", 0, REG_OK, 0, 1, END);
+  test_comp("\\o5", REG_EXTENDED, 0);
+  test_exec("\005", 0, REG_OK, 0, 1, END);
+  test_comp("\\o5r", REG_EXTENDED, 0);
+  test_exec("\005r", 0, REG_OK, 0, 2, END);
+  test_comp("\\o", REG_EXTENDED, 0);
+  test_nexec("\000", 1, 0, REG_OK, 0, 1, END);
+  test_comp("\\or", REG_EXTENDED, 0);
+  test_nexec("\000r", 2, 0, REG_OK, 0, 2, END);
+  test_comp("\\o{101}", REG_EXTENDED, 0);
+  test_exec("ABC", 0, REG_OK, 0, 1, END);
+  test_comp("\\o{5}", REG_EXTENDED, 0);
+  test_exec("\005", 0, REG_OK, 0, 1, END);
+  test_comp("\\o{5}r", REG_EXTENDED, 0);
+  test_exec("\005r", 0, REG_OK, 0, 2, END);
+  test_comp("\\o{}", REG_EXTENDED, 0);
+  test_nexec("\000", 1, 0, REG_OK, 0, 1, END);
+  test_comp("\\o{}r", REG_EXTENDED, 0);
+  test_nexec("\000r", 2, 0, REG_OK, 0, 2, END);
+  test_comp("\\o{00000000000}", REG_EXTENDED, 0);
+  test_comp("\\o{37777777777}", REG_EXTENDED, 0);
+  test_comp("\\o{40000000000}", REG_EXTENDED, REG_EBRACE);
+
   /* Test the \x1B and \x{263a} extensions for specifying 8 bit and wide
      characters in hexadecimal. */
   test_comp("\\x41", REG_EXTENDED, 0);
@@ -1390,7 +1416,10 @@ main(int argc, char **argv)
   test_comp("\\x{}r", REG_EXTENDED, 0);
   test_nexec("\000r", 2, 0, REG_OK, 0, 2, END);
   test_comp("\\x{00000000}", REG_EXTENDED, 0);
-  test_comp("\\x{000000000}", REG_EXTENDED, REG_EBRACE);
+  test_comp("\\x{ffffffff}", REG_EXTENDED, 0);
+  test_comp("\\x{000000000}", REG_EXTENDED, 0);
+  test_comp("\\x{0ffffffff}", REG_EXTENDED, 0);
+  test_comp("\\x{100000000}", REG_EXTENDED, REG_EBRACE);
 
   /* Tests for (?inrU-inrU) and (?inrU-inrU:) */
   test_comp("foo(?i)bar", REG_EXTENDED, 0);


### PR DESCRIPTION
* Rewrite the hexadecimal escape parser to support sequences of arbitrary length as long as they don't overflow.
* Replicate the same logic for octal escapes using a `\o` prefix.  This improves compatibility with e.g. GNU sed.
* Update the unit tests and documentation accordingly.