### PR TITLE
Fix BRE parentheses

### DIFF
--- a/tests/retest.c
+++ b/tests/retest.c
@@ -1166,7 +1166,12 @@ main(int argc, char **argv)
   test_comp("[[.", 0, REG_ECOLLATE);
   test_comp("[[=", 0, REG_ECOLLATE);
 
-
+  /* BRE parentheses. */
+  test_comp("\\\\(a", 0, 0);
+  test_exec("\\(a", 0, REG_OK, 0, 3, END);
+  test_comp("\\(a\\\\)\\)", 0, 0);
+  test_exec("a\\)", 0, REG_OK, 0, 3, 0, 3, END);
+  test_comp("\\(\\\\)", 0, REG_EPAREN);
 
   /* Miscellaneous tests. */
   test_comp("abc\\(\\(de\\)\\(fg\\)\\)hi", 0, 0);


### PR DESCRIPTION
Previously, when the parser encountered a left or right parenthesis while parsing an atom, it would check if it was either in ERE mode or if the preceding character was a backslash.  This is unreliable as we cannot know at this point if said backslash was itself escaped.  Instead, when we encounter a backslash (which we know is not escaped), and are not in ERE mode, check if the next character is a left or right parenthesis, and if so, jump directly to the appropriate point.