### PR TITLE
local_includes/regex.h: fix TRE_REXEX_H typo in include guard

### DIFF
--- a/local_includes/regex.h
+++ b/local_includes/regex.h
@@ -10,7 +10,7 @@
 
 */
 
-#ifndef TRE_REXEX_H
+#ifndef TRE_REGEX_H
 #define TRE_REGEX_H 1
 
 #ifdef USE_LOCAL_TRE_H


### PR DESCRIPTION
Closes #132.

The include guard in `local_includes/regex.h` is

```c
#ifndef TRE_REXEX_H
#define TRE_REGEX_H 1
...
#endif /* TRE_REGEX_H */
```

Note the mismatch: `REXEX` in the `#ifndef`, `REGEX` in the `#define` and in the closing-`#endif` comment. Because the two names don't match, a re-include doesn't short-circuit — the header re-executes every time. Rename `TRE_REXEX_H` to `TRE_REGEX_H` so the guard actually guards.

## Testing

- Single-character typo fix; no runtime behaviour change on a first include.
- Closing-`#endif` comment already says `TRE_REGEX_H`, so the new guard matches it and the paired `#ifndef`/`#endif` now form a consistent pair.