### PR TITLE
Make REG_LITERAL match the empty pattern

### DIFF
--- a/lib/tre-parse.c
+++ b/lib/tre-parse.c
@@ -1645,6 +1645,22 @@ tre_parse(tre_parse_ctx_t *ctx)
 		  break;
 		}
 
+#ifdef REG_LITERAL
+	      /* In literal mode the branch above is skipped, so an empty
+		 pattern would otherwise fall through without producing an
+		 atom.  Emit an empty expression, which matches the empty
+		 string. */
+	      if ((ctx->cflags & REG_LITERAL) && ctx->re >= ctx->re_end)
+		{
+		  DPRINT(("tre_parse:	    literal empty: '%.*" STRF "'\n",
+			  REST(ctx->re)));
+		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1);
+		  if (!result)
+		    return REG_ESPACE;
+		  break;
+		}
+#endif /* REG_LITERAL */
+
 	      DPRINT(("tre_parse:     literal: '%.*" STRF "'\n",
 		      REST(ctx->re)));
 	      /* Note that we can't use an tre_isalpha() test here, since there

--- a/tests/retest.c
+++ b/tests/retest.c
@@ -633,6 +633,23 @@ main(int argc, char **argv)
   test_exec("xxxxxx", 0, REG_NOMATCH);
 #endif
 
+  /*
+   * Literal (REG_LITERAL) patterns.
+   */
+
+  /* An empty literal pattern matches the empty string. */
+  test_comp("", REG_EXTENDED | REG_LITERAL, 0);
+  test_exec("abc", 0, REG_OK, 0, 0, END);
+  test_exec("", 0, REG_OK, 0, 0, END);
+
+  /* Metacharacters lose their meaning in literal mode. */
+  test_comp("a.c", REG_EXTENDED | REG_LITERAL, 0);
+  test_exec("xa.cy", 0, REG_OK, 1, 4, END);
+  test_exec("abc", 0, REG_NOMATCH);
+  test_comp("(a|b)*", REG_EXTENDED | REG_LITERAL, 0);
+  test_exec("x(a|b)*y", 0, REG_OK, 1, 7, END);
+  test_exec("ababab", 0, REG_NOMATCH);
+
 #ifdef TRE_APPROX
   /*
    * Approximate matching tests.


### PR DESCRIPTION
*These pull requests were generated with Claude Code, but were reviewed by me (@kevinushey) before posting. I'll respond personally to any feedback; please let me know if this is okay.*

---

This makes `REG_LITERAL` match the empty pattern.

**Problem.** With `REG_LITERAL`, compiling an empty pattern succeeds, but the resulting regex never matches anything — including the empty string:

```c
tre_regcomp(&re, "", REG_EXTENDED | REG_LITERAL);
tre_regexec(&re, "abc", 1, m, 0);   /* returns REG_NOMATCH */
```

Expected: an empty pattern matches the empty string at offset 0 in any subject, as it does without `REG_LITERAL` and in other regex engines.

**Cause.** The `PARSE_ATOM` empty-expression branch is explicitly skipped in literal mode (`!(ctx->cflags & REG_LITERAL) && ...`), so an empty pattern falls through without ever producing an atom.

**Fix.** In literal mode at end of pattern, emit an `EMPTY` literal node, mirroring the non-literal branch. The guard uses `ctx->re >= ctx->re_end` so it also covers `tre_regncomp(&re, "", 0, ...)`.

**Testing** (Windows x64, mingw-w64 gcc 14):

```
compile "" LITERAL                           PASS
"" matches in "abc" at (0,0)                 PASS   (unpatched: FAIL)
"" matches in "" at (0,0)                    PASS   (unpatched: FAIL)
regncomp len=0 LITERAL matches               PASS   (unpatched: FAIL)
literal "a.c" still matches only "a.c"       PASS
non-literal "" still matches (baseline)      PASS
```

**Provenance.** A variant of this fix has been carried in GNU R's vendored copy of TRE since 2009, where `REG_LITERAL` backs R's `fixed = TRUE` matching.
