### PR TITLE
publish documentation as a github pages website

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Publish documentation
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build website
+    runs-on: ubuntu-latest
+    steps:
+    - name: Prepare
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pandoc
+    - name: Check out
+      uses: actions/checkout@v4
+    - name: Build website
+      run: ./doc/build-website.sh _site
+    - name: Upload website
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: _site
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/doc/build-website.sh
+++ b/doc/build-website.sh
@@ -1,0 +1,79 @@
+#! /bin/sh
+#
+# Assembles the documentation website published via GitHub Pages.
+# Requires pandoc, which is used to convert README.md to HTML.
+#
+# Usage: doc/build-website.sh [output-directory]
+#
+
+set -e
+
+srcdir=`dirname "$0"`
+outdir=${1:-_site}
+
+if ! command -v pandoc > /dev/null 2>&1; then
+  echo "error: pandoc is required to build the website" >&2
+  exit 1
+fi
+
+mkdir -p "$outdir"
+cp "$srcdir/default.css" "$outdir"
+
+# The HTML files in doc/ are body fragments with no <html> or <head>;
+# they were originally embedded in a site template.  This wraps a
+# fragment (read from stdin) into a complete page.
+emit_page() {
+  title=$1
+  out=$2
+
+  {
+    cat << EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>$title</title>
+<link rel="stylesheet" href="default.css">
+<style>
+body {
+  max-width: 50em;
+  margin: 0 auto;
+  padding: 0 1em 2em 1em;
+  font-family: sans-serif;
+  line-height: 1.5;
+}
+nav.site {
+  border-bottom: 1px solid #cbc5b8;
+  padding: 0.5em 0;
+  margin-bottom: 1.5em;
+}
+nav.site a {
+  margin-right: 1em;
+}
+</style>
+</head>
+<body>
+<nav class="site">
+<a href="index.html">TRE</a>
+<a href="tre-api.html">API reference</a>
+<a href="tre-syntax.html">Regexp syntax</a>
+<a href="https://github.com/laurikari/tre">GitHub</a>
+</nav>
+EOF
+    cat
+    cat << EOF
+</body>
+</html>
+EOF
+  } > "$out"
+}
+
+pandoc --from gfm --to html "$srcdir/../README.md" \
+  | emit_page "TRE" "$outdir/index.html"
+
+emit_page "TRE API reference manual" "$outdir/tre-api.html" \
+  < "$srcdir/tre-api.html"
+
+emit_page "TRE Regexp Syntax" "$outdir/tre-syntax.html" \
+  < "$srcdir/tre-syntax.html"


### PR DESCRIPTION
## Summary

This adds an opt-in GitHub Actions workflow that publishes the project documentation as a GitHub Pages website at https://laurikari.github.io/tre/.

- `doc/build-website.sh` assembles a small static site: it converts `README.md` into an index page with pandoc, and wraps `doc/tre-api.html` and `doc/tre-syntax.html` (which are body-only HTML fragments, presumably from the old tre.laurikari.com site template) in a minimal page template with a navigation header. The pages are styled with the existing `doc/default.css`.
- `.github/workflows/pages.yml` runs the script on every push to `master` and deploys the result to GitHub Pages.

No existing files are modified, and nothing is published unless GitHub Pages is enabled for the repository (see below).

## Activating (requires repo admin)

1. Go to **Settings -> Pages**.
2. Under "Build and deployment", set **Source** to **GitHub Actions**.
3. Merge this PR. If it was merged before Pages was enabled, run the "Publish documentation" workflow manually from the Actions tab (or push any commit to `master`).

The site will then be live at https://laurikari.github.io/tre/ and will update automatically on every push to `master`.

Note: if this is merged while Pages is still disabled, the deploy job will fail on each push to `master` (harmless, but noisy). Either enable Pages, or disable the "Publish documentation" workflow from the Actions tab.

## Testing

Built locally with pandoc 3.10 and verified that all three pages (index, API reference, regexp syntax) render as complete, styled HTML documents.

Possible follow-up, if there is interest: render the agrep man page (`doc/agrep.1.in`) to HTML as part of the site.
