### PR TITLE
Fix pointer truncation and under-alignment in ALIGN() on LLP64 platforms

### DIFF
--- a/lib/tre-internal.h
+++ b/lib/tre-internal.h
@@ -22,6 +22,7 @@
 
 #include <limits.h>
 #include <ctype.h>
+#include <stddef.h>
 
 #include "tre/tre.h"
 
@@ -137,11 +138,23 @@ tre_ctype_t tre_ctype(const char *name);
 
 typedef enum { STR_WIDE, STR_BYTE, STR_MBS, STR_USER } tre_str_type_t;
 
+/* A union with the strictest alignment of the objects TRE places in
+   its memory blocks.  Aligning to `long' is not enough on LLP64
+   platforms such as 64-bit Windows, where `long' is narrower than
+   pointers and doubles. */
+typedef union {
+  void *ptr;
+  void (*fn)(void);
+  long long ll;
+  double d;
+} tre_aligned_t;
+
 /* Returns number of bytes to add to (char *)ptr to make it
-   properly aligned for the type. */
+   properly aligned for the type.  The cast must be to `size_t', not
+   `long', which would truncate the pointer on LLP64 platforms. */
 #define ALIGN(ptr, type) \
-  ((((long)ptr) % sizeof(type)) \
-   ? (sizeof(type) - (((long)ptr) % sizeof(type))) \
+  ((((size_t)ptr) % sizeof(type)) \
+   ? (sizeof(type) - (((size_t)ptr) % sizeof(type))) \
    : 0)
 
 #undef MAX

--- a/lib/tre-match-approx.c
+++ b/lib/tre-match-approx.c
@@ -295,17 +295,17 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
     /* Allocate `tmp_tags' from `buf'. */
     tmp_tags = (void *)buf;
     buf_cursor = buf + tag_bytes;
-    buf_cursor += ALIGN(buf_cursor, long);
+    buf_cursor += ALIGN(buf_cursor, tre_aligned_t);
 
     /* Allocate `reach' from `buf'. */
     reach = (void *)buf_cursor;
     buf_cursor += reach_bytes;
-    buf_cursor += ALIGN(buf_cursor, long);
+    buf_cursor += ALIGN(buf_cursor, tre_aligned_t);
 
     /* Allocate `reach_next' from `buf'. */
     reach_next = (void *)buf_cursor;
     buf_cursor += reach_bytes;
-    buf_cursor += ALIGN(buf_cursor, long);
+    buf_cursor += ALIGN(buf_cursor, tre_aligned_t);
 
     /* Allocate tag arrays for `reach' and `reach_next' from `buf'. */
     for (i = 0; i < tnfa->num_states; i++)

--- a/lib/tre-match-parallel.c
+++ b/lib/tre-match-parallel.c
@@ -186,16 +186,16 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
     /* Get the various pointers within tmp_buf (properly aligned). */
     tmp_tags = (void *)buf;
     tmp_buf = buf + tbytes;
-    tmp_buf += ALIGN(tmp_buf, long);
+    tmp_buf += ALIGN(tmp_buf, tre_aligned_t);
     reach_next = (void *)tmp_buf;
     tmp_buf += rbytes;
-    tmp_buf += ALIGN(tmp_buf, long);
+    tmp_buf += ALIGN(tmp_buf, tre_aligned_t);
     reach = (void *)tmp_buf;
     tmp_buf += rbytes;
-    tmp_buf += ALIGN(tmp_buf, long);
+    tmp_buf += ALIGN(tmp_buf, tre_aligned_t);
     reach_pos = (void *)tmp_buf;
     tmp_buf += pbytes;
-    tmp_buf += ALIGN(tmp_buf, long);
+    tmp_buf += ALIGN(tmp_buf, tre_aligned_t);
     for (i = 0; i < tnfa->num_states; i++)
       {
 	reach[i].tags = (void *)tmp_buf;

--- a/lib/tre-mem.c
+++ b/lib/tre-mem.c
@@ -138,7 +138,7 @@ tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
     }
 
   /* Make sure the next pointer will be aligned. */
-  size += ALIGN(mem->ptr + size, long);
+  size += ALIGN(mem->ptr + size, tre_aligned_t);
 
   /* Allocate from current block. */
   ptr = mem->ptr;


### PR DESCRIPTION
`ALIGN()` computes the padding needed to align a pointer by casting it through `long`. That has two problems on LLP64 platforms (64-bit Windows), where `long` is 32 bits:

- the cast truncates the pointer before the remainder is computed, so the padding itself can be wrong; and
- the buffers carved up with `ALIGN(..., long)` in `tre-mem.c`, `tre-match-parallel.c`, and `tre-match-approx.c` store pointers and structs containing pointers, which need 8-byte alignment, while `sizeof(long)` is 4.

This changes the cast to `size_t` and introduces a `tre_aligned_t` union (pointer, function pointer, `long long`, `double`) used as the alignment type at all call sites.

No functional change on LP64 platforms, where `long` already has pointer width. `make check` passes on macOS arm64 (clang). R's bundled copy of TRE has carried an equivalent fix for its 64-bit Windows builds for many years.
