### PR TITLE
Do not use the system wctype() on Windows

### DIFF
--- a/lib/tre-internal.h
+++ b/lib/tre-internal.h
@@ -119,7 +119,12 @@ typedef short tre_cint_t;
 
 #endif /* !TRE_WCHAR */
 
-#if defined(TRE_WCHAR) && defined(HAVE_ISWCTYPE) && defined(HAVE_WCTYPE)
+/* Do not use the system iswctype()/wctype() on Windows: the CRT has no
+   "blank" character class (wctype("blank") returns 0, so [[:blank:]]
+   fails with REG_ECTYPE), and iswprint(L'\t') incorrectly returns true.
+   TRE's own implementations in tre-parse.c handle both. */
+#if !defined(_WIN32) && \
+  defined(TRE_WCHAR) && defined(HAVE_ISWCTYPE) && defined(HAVE_WCTYPE)
 #define TRE_USE_SYSTEM_WCTYPE 1
 #endif
 


### PR DESCRIPTION
On Windows, `HAVE_ISWCTYPE` and `HAVE_WCTYPE` are defined (both in `win32/config.h` and by configure under MinGW), so `TRE_USE_SYSTEM_WCTYPE` is enabled. But the Windows CRT's `wctype()` has no `"blank"` class -- `wctype("blank")` returns 0, so a pattern using `[[:blank:]]` fails to compile with `REG_ECTYPE`. The CRT's `iswprint(L'\t')` also incorrectly returns true, so `[[:print:]]` matches a tab.

TRE already carries fixes for both in the `!TRE_USE_SYSTEM_WCTYPE` path -- `tre_isblank_func()`, and the Windows tab check in `tre_isprint_func()` imported from #106 -- but they are currently unreachable on Windows because the system-wctype path is selected instead.

This excludes `_WIN32` from the `TRE_USE_SYSTEM_WCTYPE` condition so that TRE's own class-function table is used there, making those existing workarounds effective. R's bundled copy of TRE has shipped this opt-out for many years.

No change on other platforms; `make check` passes on macOS.
